### PR TITLE
feat: Add Subject Grid page with unified view of radicals, kanji, and vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2025-12-08
+
+### Added
+- **Subject Grid Page**: Visual overview of all WaniKani learning items
+  - New `/kanji` route (renamed from kanji-specific to all subjects)
+  - Displays radicals, kanji, and vocabulary in a unified grid
+  - Color-coded top borders to distinguish subject types:
+    - Blue (#00AAFF) for radicals
+    - Pink (#FF00AA) for kanji
+    - Purple (#AA00FF) for vocabulary
+  - SRS stage colors for cell backgrounds (locked through burned)
+  - Flexible cell widths to accommodate multi-character vocabulary
+  - Radical image support for radicals without character representations
+- **Grid Features**:
+  - Dual view modes: flat grid or grouped by level
+  - Filtering by level range (1-60)
+  - Filtering by SRS stage
+  - Filtering by subject type (radical/kanji/vocabulary)
+  - Search by character, meaning, or reading
+  - Hover tooltips with item details
+  - Click to open item on WaniKani
+- **Performance Optimizations**:
+  - Lazy-loaded level sections via Intersection Observer
+  - Memoized cell components
+  - Deferred search for responsive typing
+- **Navigation**: Added "Kanji" link to header and mobile nav
+
+### Technical
+- Added `src/pages/kanji.tsx` - Subject grid page
+- Added `src/components/kanji-grid/` - Grid component suite
+- Added `src/lib/calculations/kanji-grid.ts` - Subject enrichment and filtering
+- Updated `src/App.tsx` with new route
+- Updated navigation components with new link
+
 ## [2.3.0] - 2025-12-02
 
 ### Added
@@ -332,6 +366,7 @@ WaniTrack v2.0.0 - Complete WaniKani statistics tracker and analytics platform.
 
 ## Version History Summary
 
+- **2.4.0** (Dec 8, 2025) - Subject grid page with radicals, kanji, vocabulary visualization
 - **2.3.0** (Dec 2, 2025) - Data export system, hidden item tracking, caching overhaul
 - **2.2.0** (Nov 30, 2025) - Customizable averaging, review counter fix, icon update
 - **2.1.1** (Nov 30, 2025) - Intelligent level averaging, modal system, toast notifications

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wanitrack",
-  "version": "2.1.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wanitrack",
-      "version": "2.1.2",
+      "version": "2.3.0",
       "dependencies": {
         "@tanstack/react-query": "^5.90.11",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ const Dashboard = lazy(() => import('./pages/dashboard').then(m => ({ default: m
 const Progress = lazy(() => import('./pages/progress').then(m => ({ default: m.Progress })))
 const Accuracy = lazy(() => import('./pages/accuracy').then(m => ({ default: m.Accuracy })))
 const Leeches = lazy(() => import('./pages/leeches').then(m => ({ default: m.Leeches })))
+const Kanji = lazy(() => import('./pages/kanji').then(m => ({ default: m.Kanji })))
 const Settings = lazy(() => import('./pages/settings').then(m => ({ default: m.Settings })))
 const Setup = lazy(() => import('./pages/setup').then(m => ({ default: m.Setup })))
 
@@ -76,6 +77,7 @@ function AppContent() {
             <Route path="/progress" element={<Progress />} />
             <Route path="/accuracy" element={<Accuracy />} />
             <Route path="/leeches" element={<Leeches />} />
+            <Route path="/kanji" element={<Kanji />} />
             <Route path="/settings" element={<Settings />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/src/components/kanji-grid/kanji-cell.tsx
+++ b/src/components/kanji-grid/kanji-cell.tsx
@@ -1,0 +1,67 @@
+import { memo } from 'react'
+import { cn } from '@/lib/utils/cn'
+import type { EnrichedSubject } from '@/lib/calculations/kanji-grid'
+import { getSRSCellClasses, getSubjectTypeColor } from '@/lib/calculations/kanji-grid'
+
+interface SubjectCellProps {
+  subject: EnrichedSubject
+  onClick: () => void
+  onMouseEnter: (event: React.MouseEvent) => void
+  onMouseLeave: () => void
+}
+
+function SubjectCellComponent({ subject, onClick, onMouseEnter, onMouseLeave }: SubjectCellProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className={cn(
+        // Flexible width - expands for vocabulary
+        'min-w-10 h-10 sm:min-w-12 sm:h-12',
+        // Padding
+        'px-1.5',
+        // Layout
+        'flex items-center justify-center',
+        // Text - adjust size for longer words
+        subject.character && subject.character.length > 1 ? 'text-base sm:text-lg' : 'text-lg sm:text-xl',
+        'font-medium',
+        // Style
+        'rounded-md',
+        'cursor-pointer',
+        'transition-all duration-200',
+        // Type indicator - colored top border (2px)
+        'border-t-2',
+        getSubjectTypeColor(subject.subjectType),
+        // Hover effects
+        'hover:scale-110 hover:shadow-md hover:z-10',
+        // Focus
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vermillion-500 focus-visible:ring-offset-2',
+        // SRS-based colors
+        getSRSCellClasses(subject.srsStage)
+      )}
+      aria-label={`${subject.character || subject.primaryMeaning} - ${subject.primaryMeaning} - ${subject.srsStageName} - ${subject.subjectType}`}
+    >
+      {subject.character ? (
+        <span>{subject.character}</span>
+      ) : subject.characterImageUrl ? (
+        <img
+          src={subject.characterImageUrl}
+          alt={subject.primaryMeaning}
+          className="w-6 h-6 dark:invert"
+        />
+      ) : (
+        <span className="text-ink-300 dark:text-paper-300">?</span>
+      )}
+    </button>
+  )
+}
+
+// Memoize with custom comparison (only re-render if id or srsStage changes)
+export const KanjiCell = memo(SubjectCellComponent, (prevProps, nextProps) => {
+  return (
+    prevProps.subject.id === nextProps.subject.id &&
+    prevProps.subject.srsStage === nextProps.subject.srsStage
+  )
+})

--- a/src/components/kanji-grid/kanji-grid-filters.tsx
+++ b/src/components/kanji-grid/kanji-grid-filters.tsx
@@ -1,0 +1,215 @@
+import { Search, Grid2X2, List } from 'lucide-react'
+import type { SRSStage } from '@/lib/api/types'
+import type { SubjectType } from '@/lib/calculations/kanji-grid'
+import { cn } from '@/lib/utils/cn'
+
+interface KanjiGridFiltersProps {
+  viewMode: 'flat' | 'grouped'
+  onViewModeChange: (mode: 'flat' | 'grouped') => void
+  levelRange: [number, number]
+  onLevelRangeChange: (range: [number, number]) => void
+  srsFilter: SRSStage[]
+  onSrsFilterChange: (stages: SRSStage[]) => void
+  subjectTypeFilter: SubjectType[]
+  onSubjectTypeFilterChange: (types: SubjectType[]) => void
+  searchQuery: string
+  onSearchChange: (query: string) => void
+  totalCount: number
+  filteredCount: number
+}
+
+const srsStages: { value: SRSStage; label: string }[] = [
+  { value: 'initiate', label: 'Locked' },
+  { value: 'apprentice', label: 'Apprentice' },
+  { value: 'guru', label: 'Guru' },
+  { value: 'master', label: 'Master' },
+  { value: 'enlightened', label: 'Enlightened' },
+  { value: 'burned', label: 'Burned' },
+]
+
+const subjectTypes: { value: SubjectType; label: string; color: string }[] = [
+  { value: 'radical', label: 'Radicals', color: 'bg-[#00AAFF]' },
+  { value: 'kanji', label: 'Kanji', color: 'bg-[#FF00AA]' },
+  { value: 'vocabulary', label: 'Vocabulary', color: 'bg-[#AA00FF]' },
+]
+
+export function KanjiGridFilters({
+  viewMode,
+  onViewModeChange,
+  levelRange,
+  onLevelRangeChange,
+  srsFilter,
+  onSrsFilterChange,
+  subjectTypeFilter,
+  onSubjectTypeFilterChange,
+  searchQuery,
+  onSearchChange,
+  totalCount,
+  filteredCount,
+}: KanjiGridFiltersProps) {
+  const toggleSrsStage = (stage: SRSStage) => {
+    if (srsFilter.includes(stage)) {
+      onSrsFilterChange(srsFilter.filter((s) => s !== stage))
+    } else {
+      onSrsFilterChange([...srsFilter, stage])
+    }
+  }
+
+  const toggleSubjectType = (type: SubjectType) => {
+    if (subjectTypeFilter.includes(type)) {
+      onSubjectTypeFilterChange(subjectTypeFilter.filter((t) => t !== type))
+    } else {
+      onSubjectTypeFilterChange([...subjectTypeFilter, type])
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* View Mode Toggle and Count */}
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <div className="flex items-center gap-2 bg-paper-200 dark:bg-ink-200 rounded-lg p-1">
+          <button
+            type="button"
+            onClick={() => onViewModeChange('flat')}
+            className={cn(
+              'flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+              viewMode === 'flat'
+                ? 'bg-paper-100 dark:bg-ink-100 text-ink-100 dark:text-paper-100 shadow-sm'
+                : 'text-ink-300 dark:text-paper-300 hover:text-ink-100 dark:hover:text-paper-100'
+            )}
+          >
+            <Grid2X2 className="w-4 h-4" />
+            Flat
+          </button>
+          <button
+            type="button"
+            onClick={() => onViewModeChange('grouped')}
+            className={cn(
+              'flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+              viewMode === 'grouped'
+                ? 'bg-paper-100 dark:bg-ink-100 text-ink-100 dark:text-paper-100 shadow-sm'
+                : 'text-ink-300 dark:text-paper-300 hover:text-ink-100 dark:hover:text-paper-100'
+            )}
+          >
+            <List className="w-4 h-4" />
+            By Level
+          </button>
+        </div>
+
+        <div className="text-sm text-ink-300 dark:text-paper-300">
+          Showing <span className="font-medium text-ink-100 dark:text-paper-100">{filteredCount}</span> of{' '}
+          <span className="font-medium">{totalCount}</span> items
+        </div>
+      </div>
+
+      {/* Search and Level Range */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-ink-300 dark:text-paper-300" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search character, meaning, or reading..."
+            className="w-full pl-10 pr-4 py-2 bg-paper-200 dark:bg-ink-200 text-ink-100 dark:text-paper-100 placeholder-ink-300 dark:placeholder-paper-300 border border-paper-300 dark:border-ink-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-vermillion-500"
+          />
+        </div>
+
+        {/* Level Range */}
+        <div className="flex items-center gap-3">
+          <label className="text-sm font-medium text-ink-200 dark:text-paper-200 whitespace-nowrap">
+            Levels:
+          </label>
+          <div className="flex items-center gap-2 flex-1">
+            <input
+              type="number"
+              min={1}
+              max={60}
+              value={levelRange[0]}
+              onChange={(e) => {
+                const min = Math.max(1, Math.min(60, parseInt(e.target.value) || 1))
+                onLevelRangeChange([min, Math.max(min, levelRange[1])])
+              }}
+              className="w-16 px-2 py-1.5 bg-paper-200 dark:bg-ink-200 text-ink-100 dark:text-paper-100 border border-paper-300 dark:border-ink-300 rounded text-center focus:outline-none focus:ring-2 focus:ring-vermillion-500"
+            />
+            <span className="text-ink-300 dark:text-paper-300">to</span>
+            <input
+              type="number"
+              min={1}
+              max={60}
+              value={levelRange[1]}
+              onChange={(e) => {
+                const max = Math.max(1, Math.min(60, parseInt(e.target.value) || 60))
+                onLevelRangeChange([Math.min(levelRange[0], max), max])
+              }}
+              className="w-16 px-2 py-1.5 bg-paper-200 dark:bg-ink-200 text-ink-100 dark:text-paper-100 border border-paper-300 dark:border-ink-300 rounded text-center focus:outline-none focus:ring-2 focus:ring-vermillion-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Subject Type Filter */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-ink-200 dark:text-paper-200">Item Types:</label>
+        <div className="flex flex-wrap gap-2">
+          {subjectTypes.map((type) => (
+            <button
+              key={type.value}
+              type="button"
+              onClick={() => toggleSubjectType(type.value)}
+              className={cn(
+                'px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border-2',
+                subjectTypeFilter.includes(type.value) || subjectTypeFilter.length === 0
+                  ? `${type.color} text-paper-100 border-transparent`
+                  : 'bg-paper-200 dark:bg-ink-200 text-ink-300 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-current'
+              )}
+            >
+              {type.label}
+            </button>
+          ))}
+          {subjectTypeFilter.length > 0 && subjectTypeFilter.length < 3 && (
+            <button
+              type="button"
+              onClick={() => onSubjectTypeFilterChange([])}
+              className="px-3 py-1.5 rounded-lg text-sm font-medium text-ink-300 dark:text-paper-300 hover:text-vermillion-500 underline"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* SRS Stage Filter */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-ink-200 dark:text-paper-200">SRS Stages:</label>
+        <div className="flex flex-wrap gap-2">
+          {srsStages.map((stage) => (
+            <button
+              key={stage.value}
+              type="button"
+              onClick={() => toggleSrsStage(stage.value)}
+              className={cn(
+                'px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border',
+                srsFilter.includes(stage.value) || srsFilter.length === 0
+                  ? 'bg-vermillion-500 text-paper-100 border-vermillion-500'
+                  : 'bg-paper-200 dark:bg-ink-200 text-ink-300 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-vermillion-500'
+              )}
+            >
+              {stage.label}
+            </button>
+          ))}
+          {srsFilter.length > 0 && (
+            <button
+              type="button"
+              onClick={() => onSrsFilterChange([])}
+              className="px-3 py-1.5 rounded-lg text-sm font-medium text-ink-300 dark:text-paper-300 hover:text-vermillion-500 underline"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/kanji-grid/kanji-grid-legend.tsx
+++ b/src/components/kanji-grid/kanji-grid-legend.tsx
@@ -1,0 +1,58 @@
+import type { SRSStage } from '@/lib/api/types'
+import { cn } from '@/lib/utils/cn'
+
+interface KanjiGridLegendProps {
+  distribution: Record<SRSStage, number>
+}
+
+const stageInfo: Record<SRSStage, { label: string; colorClass: string }> = {
+  initiate: { label: 'Locked', colorClass: 'bg-paper-300 dark:bg-ink-300' },
+  apprentice: { label: 'Apprentice', colorClass: 'bg-srs-apprentice' },
+  guru: { label: 'Guru', colorClass: 'bg-srs-guru' },
+  master: { label: 'Master', colorClass: 'bg-srs-master' },
+  enlightened: { label: 'Enlightened', colorClass: 'bg-srs-enlightened' },
+  burned: { label: 'Burned', colorClass: 'bg-srs-burned' },
+}
+
+const subjectTypes = [
+  { label: 'Radical', colorClass: 'border-t-[#00AAFF]' },
+  { label: 'Kanji', colorClass: 'border-t-[#FF00AA]' },
+  { label: 'Vocabulary', colorClass: 'border-t-[#AA00FF]' },
+]
+
+export function KanjiGridLegend({ distribution }: KanjiGridLegendProps) {
+  const stages: SRSStage[] = ['initiate', 'apprentice', 'guru', 'master', 'enlightened', 'burned']
+
+  return (
+    <div className="space-y-3">
+      {/* Subject Type Legend */}
+      <div className="flex flex-wrap items-center gap-4 text-sm">
+        <span className="text-ink-300 dark:text-paper-300 font-medium">Item Types:</span>
+        {subjectTypes.map((type) => (
+          <div key={type.label} className="flex items-center gap-2">
+            <div className={cn('w-4 h-4 rounded bg-paper-200 dark:bg-ink-200 border-t-2', type.colorClass)} />
+            <span className="text-ink-200 dark:text-paper-200">{type.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* SRS Stage Legend */}
+      <div className="flex flex-wrap items-center gap-4 text-sm">
+        <span className="text-ink-300 dark:text-paper-300 font-medium">SRS Stages:</span>
+        {stages.map((stage) => {
+          const info = stageInfo[stage]
+          const count = distribution[stage] ?? 0
+
+          return (
+            <div key={stage} className="flex items-center gap-2">
+              <div className={cn('w-4 h-4 rounded', info.colorClass)} />
+              <span className="text-ink-200 dark:text-paper-200">
+                {info.label} <span className="text-ink-300 dark:text-paper-300">({count})</span>
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/kanji-grid/kanji-grid.tsx
+++ b/src/components/kanji-grid/kanji-grid.tsx
@@ -1,0 +1,250 @@
+import { useState, useMemo, useDeferredValue } from 'react'
+import { useSubjects } from '@/lib/api/queries'
+import { useAssignments } from '@/lib/api/queries'
+import type { SRSStage } from '@/lib/api/types'
+import type { EnrichedSubject, SubjectType } from '@/lib/calculations/kanji-grid'
+import {
+  enrichSubjectsWithSRS,
+  filterSubjects,
+  groupSubjectsByLevel,
+} from '@/lib/calculations/kanji-grid'
+import { KanjiGridFilters } from './kanji-grid-filters'
+import { KanjiGridLegend } from './kanji-grid-legend'
+import { KanjiLevelSection } from './kanji-level-section'
+import { KanjiCell } from './kanji-cell'
+import { KanjiTooltip } from './kanji-tooltip'
+import { useSyncStore } from '@/stores/sync-store'
+
+export function KanjiGrid() {
+  const { data: subjects, isLoading: subjectsLoading } = useSubjects()
+  const { data: assignments, isLoading: assignmentsLoading } = useAssignments()
+  const isSyncing = useSyncStore((state) => state.isSyncing)
+
+  // Filter state
+  const [viewMode, setViewMode] = useState<'flat' | 'grouped'>('grouped')
+  const [levelRange, setLevelRange] = useState<[number, number]>([1, 60])
+  const [srsFilter, setSrsFilter] = useState<SRSStage[]>([])
+  const [subjectTypeFilter, setSubjectTypeFilter] = useState<SubjectType[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
+  const deferredSearchQuery = useDeferredValue(searchQuery)
+
+  // Tooltip state
+  const [tooltipSubject, setTooltipSubject] = useState<EnrichedSubject | null>(null)
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 })
+
+  const isLoading = subjectsLoading || assignmentsLoading || isSyncing
+
+  // Step 1: Enrich subjects with SRS data
+  const enrichedSubjects = useMemo(() => {
+    if (!subjects || !assignments) return []
+    return enrichSubjectsWithSRS(subjects, assignments)
+  }, [subjects, assignments])
+
+  // Step 2: Apply filters
+  const filteredSubjects = useMemo(() => {
+    return filterSubjects(enrichedSubjects, {
+      levelRange,
+      srsStages: srsFilter.length > 0 ? srsFilter : undefined,
+      subjectTypes: subjectTypeFilter.length > 0 ? subjectTypeFilter : undefined,
+      searchQuery: deferredSearchQuery,
+    })
+  }, [enrichedSubjects, levelRange, srsFilter, subjectTypeFilter, deferredSearchQuery])
+
+  // Step 3: Group by level (if needed)
+  const subjectsByLevel = useMemo(() => {
+    return viewMode === 'grouped' ? groupSubjectsByLevel(filteredSubjects) : null
+  }, [filteredSubjects, viewMode])
+
+  // Calculate SRS distribution for legend
+  const srsDistribution = useMemo(() => {
+    const dist: Record<SRSStage, number> = {
+      initiate: 0,
+      apprentice: 0,
+      guru: 0,
+      master: 0,
+      enlightened: 0,
+      burned: 0,
+    }
+
+    filteredSubjects.forEach((subject) => {
+      dist[subject.srsStageName] = (dist[subject.srsStageName] || 0) + 1
+    })
+
+    return dist
+  }, [filteredSubjects])
+
+  // Handlers
+  const handleSubjectClick = (subject: EnrichedSubject) => {
+    window.open(subject.documentUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  const handleSubjectHover = (subject: EnrichedSubject | null, event?: React.MouseEvent) => {
+    if (subject && event) {
+      setTooltipSubject(subject)
+      setTooltipPosition({ x: event.clientX + 16, y: event.clientY + 16 })
+    } else {
+      setTooltipSubject(null)
+    }
+  }
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        {/* Page Header Skeleton */}
+        <div>
+          <div className="h-9 w-48 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-2" />
+          <div className="h-5 w-full max-w-2xl bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+        </div>
+
+        {/* Filters Skeleton */}
+        <div className="bg-paper-100 dark:bg-ink-100 border border-paper-300 dark:border-ink-300 rounded-xl p-4 sm:p-6">
+          <div className="space-y-4">
+            {/* View mode and count */}
+            <div className="flex items-center justify-between">
+              <div className="h-10 w-40 bg-paper-300 dark:bg-ink-300 rounded-lg animate-pulse" />
+              <div className="h-5 w-32 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+            </div>
+            {/* Search and level range */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="h-10 bg-paper-300 dark:bg-ink-300 rounded-lg animate-pulse" />
+              <div className="h-10 bg-paper-300 dark:bg-ink-300 rounded-lg animate-pulse" />
+            </div>
+            {/* Type filters */}
+            <div className="space-y-2">
+              <div className="h-5 w-20 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+              <div className="flex flex-wrap gap-2">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="h-8 w-24 bg-paper-300 dark:bg-ink-300 rounded-lg animate-pulse" />
+                ))}
+              </div>
+            </div>
+            {/* SRS filters */}
+            <div className="space-y-2">
+              <div className="h-5 w-20 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+              <div className="flex flex-wrap gap-2">
+                {[1, 2, 3, 4, 5, 6].map((i) => (
+                  <div key={i} className="h-8 w-24 bg-paper-300 dark:bg-ink-300 rounded-lg animate-pulse" />
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Legend Skeleton */}
+        <div className="bg-paper-100 dark:bg-ink-100 border border-paper-300 dark:border-ink-300 rounded-xl p-4">
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <div className="h-4 w-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                  <div className="h-4 w-16 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                </div>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-4">
+              {[1, 2, 3, 4, 5, 6].map((i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <div className="h-4 w-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                  <div className="h-4 w-20 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Grid Skeleton */}
+        <div className="bg-paper-100 dark:bg-ink-100 border border-paper-300 dark:border-ink-300 rounded-xl p-4 sm:p-6">
+          <div className="flex flex-wrap gap-1 sm:gap-1.5">
+            {Array.from({ length: 80 }).map((_, i) => (
+              <div
+                key={i}
+                className="min-w-10 h-10 sm:min-w-12 sm:h-12 bg-paper-300 dark:bg-ink-300 rounded-md animate-pulse"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Empty state
+  if (enrichedSubjects.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-ink-300 dark:text-paper-300">No subjects found. Start learning to see them here!</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div>
+        <h1 className="text-3xl font-bold text-ink-100 dark:text-paper-100">Subject Grid</h1>
+        <p className="mt-2 text-ink-300 dark:text-paper-300">
+          Visual overview of all radicals, kanji, and vocabulary colored by SRS stage. Click any item to view
+          details on WaniKani.
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="bg-paper-100 dark:bg-ink-100 border border-paper-300 dark:border-ink-300 rounded-xl p-4 sm:p-6">
+        <KanjiGridFilters
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
+          levelRange={levelRange}
+          onLevelRangeChange={setLevelRange}
+          srsFilter={srsFilter}
+          onSrsFilterChange={setSrsFilter}
+          subjectTypeFilter={subjectTypeFilter}
+          onSubjectTypeFilterChange={setSubjectTypeFilter}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          totalCount={enrichedSubjects.length}
+          filteredCount={filteredSubjects.length}
+        />
+      </div>
+
+      {/* Legend */}
+      <div className="bg-paper-100 dark:bg-ink-100 border border-paper-300 dark:border-ink-300 rounded-xl p-4">
+        <KanjiGridLegend distribution={srsDistribution} />
+      </div>
+
+      {/* Grid */}
+      <div className="bg-paper-100 dark:bg-ink-100 border border-paper-300 dark:border-ink-300 rounded-xl p-4 sm:p-6">
+        {filteredSubjects.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-ink-300 dark:text-paper-300">No items match your filters.</p>
+          </div>
+        ) : viewMode === 'grouped' && subjectsByLevel ? (
+          <div className="space-y-6">
+            {subjectsByLevel.map((levelData) => (
+              <KanjiLevelSection
+                key={levelData.level}
+                levelData={levelData}
+                onSubjectClick={handleSubjectClick}
+                onSubjectHover={handleSubjectHover}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-1 sm:gap-1.5">
+            {filteredSubjects.map((subject) => (
+              <KanjiCell
+                key={subject.id}
+                subject={subject}
+                onClick={() => handleSubjectClick(subject)}
+                onMouseEnter={(e) => handleSubjectHover(subject, e)}
+                onMouseLeave={() => handleSubjectHover(null)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Tooltip */}
+      <KanjiTooltip subject={tooltipSubject} position={tooltipPosition} visible={!!tooltipSubject} />
+    </div>
+  )
+}

--- a/src/components/kanji-grid/kanji-level-section.tsx
+++ b/src/components/kanji-grid/kanji-level-section.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect, useRef } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import type { SubjectsByLevel, EnrichedSubject } from '@/lib/calculations/kanji-grid'
+import { KanjiCell } from './kanji-cell'
+
+interface KanjiLevelSectionProps {
+  levelData: SubjectsByLevel
+  onSubjectClick: (subject: EnrichedSubject) => void
+  onSubjectHover: (subject: EnrichedSubject | null, event?: React.MouseEvent) => void
+}
+
+export function KanjiLevelSection({ levelData, onSubjectClick, onSubjectHover }: KanjiLevelSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(true)
+  const [isInView, setIsInView] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Lazy loading with Intersection Observer
+  useEffect(() => {
+    if (!ref.current) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true)
+          observer.disconnect() // Only need to observe once
+        }
+      },
+      { rootMargin: '200px' } // Preload slightly before visible
+    )
+
+    observer.observe(ref.current)
+    return () => observer.disconnect()
+  }, [])
+
+  const { stats } = levelData
+
+  // Calculate highest stage count for badge display
+  const highestStage = (() => {
+    if (stats.burned > 0) return `${stats.burned}/${stats.total} burned`
+    if (stats.enlightened > 0) return `${stats.enlightened}/${stats.total} enlightened`
+    if (stats.master > 0) return `${stats.master}/${stats.total} master`
+    if (stats.guru > 0) return `${stats.guru}/${stats.total} guru`
+    if (stats.apprentice > 0) return `${stats.apprentice}/${stats.total} apprentice`
+    return `${stats.locked}/${stats.total} locked`
+  })()
+
+  return (
+    <div ref={ref} className="space-y-3">
+      {/* Level Header */}
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex items-center gap-3 w-full group"
+      >
+        <div className="flex items-center gap-2">
+          {isExpanded ? (
+            <ChevronDown className="w-5 h-5 text-ink-300 dark:text-paper-300 transition-transform group-hover:text-ink-100 dark:group-hover:text-paper-100" />
+          ) : (
+            <ChevronRight className="w-5 h-5 text-ink-300 dark:text-paper-300 transition-transform group-hover:text-ink-100 dark:group-hover:text-paper-100" />
+          )}
+          <h3 className="text-lg font-medium text-ink-100 dark:text-paper-100">Level {levelData.level}</h3>
+        </div>
+
+        <div className="text-sm text-ink-300 dark:text-paper-300">{highestStage}</div>
+
+        <div className="flex-1 h-px bg-paper-300 dark:bg-ink-300" />
+      </button>
+
+      {/* Subject Grid */}
+      {isExpanded && (
+        <>
+          {isInView ? (
+            <div className="flex flex-wrap gap-1 sm:gap-1.5">
+              {levelData.subjects.map((subject) => (
+                <KanjiCell
+                  key={subject.id}
+                  subject={subject}
+                  onClick={() => onSubjectClick(subject)}
+                  onMouseEnter={(e) => onSubjectHover(subject, e)}
+                  onMouseLeave={() => onSubjectHover(null)}
+                />
+              ))}
+            </div>
+          ) : (
+            // Placeholder to maintain layout
+            <div style={{ height: `${Math.ceil(levelData.subjects.length / 15) * 50}px` }} />
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/kanji-grid/kanji-tooltip.tsx
+++ b/src/components/kanji-grid/kanji-tooltip.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react'
+import type { EnrichedSubject } from '@/lib/calculations/kanji-grid'
+import { SRSBadge } from '@/components/shared/srs-badge'
+
+interface KanjiTooltipProps {
+  subject: EnrichedSubject | null
+  position: { x: number; y: number }
+  visible: boolean
+}
+
+export function KanjiTooltip({ subject, position, visible }: KanjiTooltipProps) {
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const [adjustedPosition, setAdjustedPosition] = useState(position)
+
+  // Adjust position to avoid overflow
+  useEffect(() => {
+    if (!tooltipRef.current || !visible) return
+
+    const tooltip = tooltipRef.current
+    const rect = tooltip.getBoundingClientRect()
+    const viewportWidth = window.innerWidth
+    const viewportHeight = window.innerHeight
+
+    let { x, y } = position
+
+    // Adjust horizontal position
+    if (x + rect.width > viewportWidth - 16) {
+      x = viewportWidth - rect.width - 16
+    }
+    if (x < 16) {
+      x = 16
+    }
+
+    // Adjust vertical position
+    if (y + rect.height > viewportHeight - 16) {
+      y = position.y - rect.height - 16 // Position above cursor
+    }
+
+    setAdjustedPosition({ x, y })
+  }, [position, visible])
+
+  if (!visible || !subject) {
+    return null
+  }
+
+  // Format subject type for display
+  const formatSubjectType = (type: string) => {
+    if (type === 'kana_vocabulary') return 'Kana Vocabulary'
+    return type.charAt(0).toUpperCase() + type.slice(1)
+  }
+
+  return (
+    <div
+      ref={tooltipRef}
+      className="fixed z-50 pointer-events-none"
+      style={{
+        left: `${adjustedPosition.x}px`,
+        top: `${adjustedPosition.y}px`,
+      }}
+    >
+      <div className="bg-paper-100 dark:bg-ink-100 border border-paper-400 dark:border-ink-400 rounded-lg shadow-lg p-3 min-w-[200px]">
+        <div className="flex items-start gap-3">
+          {/* Character or Image */}
+          <div className="text-3xl font-medium text-ink-100 dark:text-paper-100">
+            {subject.character ? (
+              subject.character
+            ) : subject.characterImageUrl ? (
+              <img
+                src={subject.characterImageUrl}
+                alt={subject.primaryMeaning}
+                className="w-8 h-8 dark:invert"
+              />
+            ) : (
+              <span className="text-ink-300 dark:text-paper-300">?</span>
+            )}
+          </div>
+
+          {/* Details */}
+          <div className="flex-1 space-y-1">
+            <div className="text-sm font-medium text-ink-100 dark:text-paper-100">{subject.primaryMeaning}</div>
+            {subject.primaryReading && (
+              <div className="text-xs text-ink-300 dark:text-paper-300">
+                {subject.primaryReading}
+                {subject.readingType && ` (${subject.readingType})`}
+              </div>
+            )}
+            <div className="flex items-center gap-2 mt-2">
+              <span className="text-xs text-ink-300 dark:text-paper-300">
+                {formatSubjectType(subject.subjectType)} · Level {subject.level}
+              </span>
+              <SRSBadge stage={subject.srsStageName} size="sm" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -13,6 +13,7 @@ const navItems = [
   { path: '/progress', label: 'Progress' },
   { path: '/accuracy', label: 'Accuracy' },
   { path: '/leeches', label: 'Leeches' },
+  { path: '/kanji', label: 'Kanji' },
 ]
 
 export function Header() {

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -18,6 +18,7 @@ const navItems = [
   { path: '/progress', label: 'Progress', japanese: '進捗' },
   { path: '/accuracy', label: 'Accuracy', japanese: '精度' },
   { path: '/leeches', label: 'Leeches', japanese: '難点' },
+  { path: '/kanji', label: 'Kanji', japanese: '漢字' },
 ]
 
 export function MobileNav({ isOpen, onClose }: MobileNavProps) {

--- a/src/lib/calculations/kanji-grid.ts
+++ b/src/lib/calculations/kanji-grid.ts
@@ -1,0 +1,318 @@
+import type { Subject, Assignment, SRSStage, KanjiSubject, RadicalSubject, VocabularySubject } from '@/lib/api/types'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type SubjectType = 'radical' | 'kanji' | 'vocabulary' | 'kana_vocabulary'
+
+export interface EnrichedSubject {
+  id: number
+  character: string | null
+  characterImageUrl: string | null
+  level: number
+  primaryMeaning: string
+  primaryReading: string | null
+  readingType: 'onyomi' | 'kunyomi' | 'nanori' | null
+  srsStage: number // 0-9
+  srsStageName: SRSStage
+  subjectType: SubjectType
+  documentUrl: string
+}
+
+export interface SubjectsByLevel {
+  level: number
+  subjects: EnrichedSubject[]
+  stats: {
+    total: number
+    locked: number
+    apprentice: number
+    guru: number
+    master: number
+    enlightened: number
+    burned: number
+  }
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Convert numeric SRS stage (0-9) to named stage
+ */
+export function getSRSStageName(stage: number): SRSStage {
+  if (stage === 0) return 'initiate'
+  if (stage >= 1 && stage <= 4) return 'apprentice'
+  if (stage >= 5 && stage <= 6) return 'guru'
+  if (stage === 7) return 'master'
+  if (stage === 8) return 'enlightened'
+  if (stage === 9) return 'burned'
+  return 'initiate' // Fallback
+}
+
+/**
+ * Determine subject type
+ */
+function getSubjectType(subject: Subject): SubjectType {
+  if ('character_images' in subject) return 'radical'
+  if ('readings' in subject && 'type' in (subject.readings[0] || {})) return 'kanji'
+  return 'vocabulary'
+}
+
+/**
+ * Check if a subject is a radical
+ */
+function isRadical(subject: Subject): subject is RadicalSubject {
+  return 'character_images' in subject
+}
+
+/**
+ * Check if a subject is a kanji
+ */
+function isKanji(subject: Subject): subject is KanjiSubject {
+  return (
+    'readings' in subject &&
+    Array.isArray(subject.readings) &&
+    subject.readings.length > 0 &&
+    'type' in subject.readings[0]
+  )
+}
+
+/**
+ * Check if a subject is vocabulary
+ */
+function isVocabulary(subject: Subject): subject is VocabularySubject {
+  return 'context_sentences' in subject && 'parts_of_speech' in subject
+}
+
+/**
+ * Extract primary reading from kanji
+ */
+function getKanjiReading(kanji: KanjiSubject): { reading: string; type: 'onyomi' | 'kunyomi' | 'nanori' } {
+  if (!kanji.readings || kanji.readings.length === 0) {
+    return { reading: '', type: 'onyomi' }
+  }
+  const primaryReading = kanji.readings.find((r) => r.primary)
+  if (primaryReading) {
+    return { reading: primaryReading.reading, type: primaryReading.type }
+  }
+  // Fallback to first reading
+  const firstReading = kanji.readings[0]
+  return firstReading
+    ? { reading: firstReading.reading, type: firstReading.type }
+    : { reading: '', type: 'onyomi' }
+}
+
+/**
+ * Extract primary reading from vocabulary
+ */
+function getVocabularyReading(vocab: VocabularySubject): string {
+  if (!vocab.readings || vocab.readings.length === 0) return ''
+  const primaryReading = vocab.readings.find((r) => r.primary)
+  return primaryReading?.reading ?? vocab.readings[0]?.reading ?? ''
+}
+
+// ============================================================================
+// Main Functions
+// ============================================================================
+
+/**
+ * Enrich subjects with SRS data from assignments
+ */
+export function enrichSubjectsWithSRS(
+  subjects: (Subject & { id: number })[],
+  assignments: Assignment[]
+): EnrichedSubject[] {
+  // Create assignment lookup map
+  const assignmentMap = new Map<number, Assignment>()
+  assignments.forEach((assignment) => {
+    assignmentMap.set(assignment.subject_id, assignment)
+  })
+
+  // Process all subjects
+  const enrichedSubjects: EnrichedSubject[] = []
+
+  subjects.forEach((subject) => {
+    const assignment = assignmentMap.get(subject.id)
+    const srsStage = assignment?.srs_stage ?? 0
+    const primaryMeaning = subject.meanings.find((m) => m.primary)?.meaning ?? subject.meanings[0]?.meaning ?? ''
+    const subjectType = getSubjectType(subject)
+
+    let character: string | null = null
+    let characterImageUrl: string | null = null
+    let primaryReading: string | null = null
+    let readingType: 'onyomi' | 'kunyomi' | 'nanori' | null = null
+
+    if (isRadical(subject)) {
+      character = subject.characters
+      characterImageUrl = subject.character_images[0]?.url ?? null
+      primaryReading = null
+      readingType = null
+    } else if (isKanji(subject)) {
+      character = subject.characters
+      characterImageUrl = null
+      const reading = getKanjiReading(subject)
+      primaryReading = reading.reading
+      readingType = reading.type
+    } else if (isVocabulary(subject)) {
+      character = subject.characters
+      characterImageUrl = null
+      primaryReading = getVocabularyReading(subject)
+      readingType = null
+    }
+
+    enrichedSubjects.push({
+      id: subject.id,
+      character,
+      characterImageUrl,
+      level: subject.level,
+      primaryMeaning,
+      primaryReading,
+      readingType,
+      srsStage,
+      srsStageName: getSRSStageName(srsStage),
+      subjectType,
+      documentUrl: subject.document_url,
+    })
+  })
+
+  // Sort by level, then by id
+  enrichedSubjects.sort((a, b) => {
+    if (a.level !== b.level) return a.level - b.level
+    return a.id - b.id
+  })
+
+  return enrichedSubjects
+}
+
+/**
+ * Filter subjects by various criteria
+ */
+export function filterSubjects(
+  subjects: EnrichedSubject[],
+  filters: {
+    levelRange?: [number, number]
+    srsStages?: SRSStage[]
+    subjectTypes?: SubjectType[]
+    searchQuery?: string
+  }
+): EnrichedSubject[] {
+  let filtered = subjects
+
+  // Filter by level range
+  if (filters.levelRange) {
+    const [min, max] = filters.levelRange
+    filtered = filtered.filter((s) => s.level >= min && s.level <= max)
+  }
+
+  // Filter by SRS stages
+  if (filters.srsStages && filters.srsStages.length > 0) {
+    filtered = filtered.filter((s) => filters.srsStages!.includes(s.srsStageName))
+  }
+
+  // Filter by subject types
+  if (filters.subjectTypes && filters.subjectTypes.length > 0) {
+    filtered = filtered.filter((s) => filters.subjectTypes!.includes(s.subjectType))
+  }
+
+  // Filter by search query (search in character, meaning, or reading)
+  if (filters.searchQuery && filters.searchQuery.trim() !== '') {
+    const query = filters.searchQuery.trim().toLowerCase()
+    filtered = filtered.filter((s) => {
+      return (
+        (s.character && s.character.includes(query)) ||
+        s.primaryMeaning.toLowerCase().includes(query) ||
+        (s.primaryReading && s.primaryReading.toLowerCase().includes(query))
+      )
+    })
+  }
+
+  return filtered
+}
+
+/**
+ * Group subjects by level with stats
+ */
+export function groupSubjectsByLevel(subjects: EnrichedSubject[]): SubjectsByLevel[] {
+  const levelMap = new Map<number, EnrichedSubject[]>()
+
+  // Group subjects by level
+  subjects.forEach((s) => {
+    const levelSubjects = levelMap.get(s.level) ?? []
+    levelSubjects.push(s)
+    levelMap.set(s.level, levelSubjects)
+  })
+
+  // Convert to array with stats
+  const grouped: SubjectsByLevel[] = []
+  levelMap.forEach((levelSubjects, level) => {
+    const stats = {
+      total: levelSubjects.length,
+      locked: levelSubjects.filter((s) => s.srsStage === 0).length,
+      apprentice: levelSubjects.filter((s) => s.srsStage >= 1 && s.srsStage <= 4).length,
+      guru: levelSubjects.filter((s) => s.srsStage >= 5 && s.srsStage <= 6).length,
+      master: levelSubjects.filter((s) => s.srsStage === 7).length,
+      enlightened: levelSubjects.filter((s) => s.srsStage === 8).length,
+      burned: levelSubjects.filter((s) => s.srsStage === 9).length,
+    }
+
+    grouped.push({
+      level,
+      subjects: levelSubjects,
+      stats,
+    })
+  })
+
+  // Sort by level
+  grouped.sort((a, b) => a.level - b.level)
+
+  return grouped
+}
+
+/**
+ * Get Tailwind CSS classes for a subject cell based on SRS stage
+ */
+export function getSRSCellClasses(srsStage: number): string {
+  switch (srsStage) {
+    case 0:
+      return 'bg-paper-300 dark:bg-ink-300 text-ink-400 dark:text-paper-400'
+    case 1:
+      return 'bg-srs-apprentice/40 text-ink-100 dark:text-paper-100'
+    case 2:
+      return 'bg-srs-apprentice/60 text-ink-100 dark:text-paper-100'
+    case 3:
+      return 'bg-srs-apprentice/80 text-ink-100 dark:text-paper-100'
+    case 4:
+      return 'bg-srs-apprentice text-ink-100 dark:text-paper-100'
+    case 5:
+      return 'bg-srs-guru/80 text-ink-100 dark:text-paper-100'
+    case 6:
+      return 'bg-srs-guru text-ink-100 dark:text-paper-100'
+    case 7:
+      return 'bg-srs-master text-ink-100 dark:text-paper-100'
+    case 8:
+      return 'bg-srs-enlightened text-ink-100 dark:text-paper-100'
+    case 9:
+      return 'bg-srs-burned text-paper-100'
+    default:
+      return 'bg-paper-300 dark:bg-ink-300'
+  }
+}
+
+/**
+ * Get subject type color for border/indicator
+ */
+export function getSubjectTypeColor(subjectType: SubjectType): string {
+  switch (subjectType) {
+    case 'radical':
+      return 'border-t-[#00AAFF]'
+    case 'kanji':
+      return 'border-t-[#FF00AA]'
+    case 'vocabulary':
+    case 'kana_vocabulary':
+      return 'border-t-[#AA00FF]'
+    default:
+      return 'border-t-ink-300'
+  }
+}

--- a/src/pages/kanji.tsx
+++ b/src/pages/kanji.tsx
@@ -1,0 +1,5 @@
+import { KanjiGrid } from '@/components/kanji-grid/kanji-grid'
+
+export function Kanji() {
+  return <KanjiGrid />
+}

--- a/src/pages/leeches.tsx
+++ b/src/pages/leeches.tsx
@@ -25,39 +25,44 @@ export function Leeches() {
     <div className="space-y-8">
       {/* Leech Summary */}
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
-        <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
-          Leech Summary
-        </h2>
         {isLoading ? (
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="text-center">
-                <div className="h-10 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-2 mx-auto w-16" />
-                <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mx-auto w-24" />
-              </div>
-            ))}
-          </div>
+          <>
+            <div className="h-6 w-40 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-4" />
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="text-center">
+                  <div className="h-10 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-2 mx-auto w-16" />
+                  <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mx-auto w-24" />
+                </div>
+              ))}
+            </div>
+          </>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-            <div className="text-center">
-              <div className="text-3xl font-display font-semibold text-vermillion-500 dark:text-vermillion-400 mb-2">
-                {leeches.length}
+          <>
+            <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
+              Leech Summary
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+              <div className="text-center">
+                <div className="text-3xl font-display font-semibold text-vermillion-500 dark:text-vermillion-400 mb-2">
+                  {leeches.length}
+                </div>
+                <div className="text-sm text-ink-400 dark:text-paper-300">Total Leeches</div>
               </div>
-              <div className="text-sm text-ink-400 dark:text-paper-300">Total Leeches</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-display font-semibold text-ochre dark:text-ochre mb-2">
-                {highSeverity}
+              <div className="text-center">
+                <div className="text-3xl font-display font-semibold text-ochre dark:text-ochre mb-2">
+                  {highSeverity}
+                </div>
+                <div className="text-sm text-ink-400 dark:text-paper-300">High Severity</div>
               </div>
-              <div className="text-sm text-ink-400 dark:text-paper-300">High Severity</div>
-            </div>
-            <div className="text-center">
-              <div className="text-3xl font-display font-semibold text-ink-400 dark:text-paper-300 mb-2">
-                {moderateSeverity}
+              <div className="text-center">
+                <div className="text-3xl font-display font-semibold text-ink-400 dark:text-paper-300 mb-2">
+                  {moderateSeverity}
+                </div>
+                <div className="text-sm text-ink-400 dark:text-paper-300">Moderate Severity</div>
               </div>
-              <div className="text-sm text-ink-400 dark:text-paper-300">Moderate Severity</div>
             </div>
-          </div>
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
  - Add new Subject Grid page (`/kanji`) displaying all WaniKani learning items in a visual grid
  - Display radicals, kanji, and vocabulary with color-coded top borders for type distinction
  - Implement flexible cell widths that dynamically size based on content length
  - Add comprehensive filtering by level range, SRS stage, and subject type
  - Include skeleton loading for consistent loading experience

  ## Features
  - **Visual Grid**: Unified view of all ~9000 WaniKani subjects
  - **Type Indicators**: Colored top borders (Blue=Radical, Pink=Kanji, Purple=Vocabulary)
  - **SRS Colors**: Background colors indicate learning progress (Locked → Burned)
  - **Flexible Cells**: Cells expand to fit multi-character vocabulary
  - **View Modes**: Toggle between flat grid and grouped-by-level views
  - **Filtering**: Filter by level (1-60), SRS stage, subject type, or search query
  - **Tooltips**: Hover for item details (meaning, reading, level, SRS stage)
  - **Click to Open**: Click any item to view on WaniKani

  ## Performance
  - Lazy-loaded level sections via Intersection Observer
  - Memoized cell components to prevent unnecessary re-renders
  - Deferred search input for responsive typing