### PR TITLE
fix: Mobile UX improvements - nav overflow and touch tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2025-12-08
+
+### Fixed
+- **Mobile Navigation Overflow**: Added scrolling to mobile drawer when content exceeds viewport height
+  - Prevents menu items from being cut off on landscape mode, small devices, or with large accessibility fonts
+  - Applied `overflow-y-auto` to drawer container
+- **Touch Device Tooltips**: Implemented tap-to-select pattern for Subject Grid on touch devices
+  - First tap selects cell and shows tooltip with item details
+  - Second tap on same cell navigates to WaniKani
+  - Tap elsewhere dismisses tooltip
+  - Desktop mouse behavior unchanged (hover shows tooltip, click navigates immediately)
+  - Selected cells show visual feedback (ring outline, scale, shadow)
+
+### Added
+- `useTouchDevice` hook for reliable touch device detection using `pointer: coarse` media query
+- Touch-aware interaction handlers in Subject Grid components
+- Visual selection state for grid cells on touch devices
+
 ## [2.4.0] - 2025-12-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/kanji-grid/kanji-cell.tsx
+++ b/src/components/kanji-grid/kanji-cell.tsx
@@ -5,12 +5,13 @@ import { getSRSCellClasses, getSubjectTypeColor } from '@/lib/calculations/kanji
 
 interface SubjectCellProps {
   subject: EnrichedSubject
-  onClick: () => void
+  isSelected?: boolean
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
   onMouseEnter: (event: React.MouseEvent) => void
   onMouseLeave: () => void
 }
 
-function SubjectCellComponent({ subject, onClick, onMouseEnter, onMouseLeave }: SubjectCellProps) {
+function SubjectCellComponent({ subject, isSelected = false, onClick, onMouseEnter, onMouseLeave }: SubjectCellProps) {
   return (
     <button
       type="button"
@@ -38,6 +39,8 @@ function SubjectCellComponent({ subject, onClick, onMouseEnter, onMouseLeave }: 
         'hover:scale-110 hover:shadow-md hover:z-10',
         // Focus
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vermillion-500 focus-visible:ring-offset-2',
+        // Selected state - ring outline for touch devices
+        isSelected && 'ring-2 ring-vermillion-500 ring-offset-2 scale-110 shadow-lg z-10',
         // SRS-based colors
         getSRSCellClasses(subject.srsStage)
       )}
@@ -58,10 +61,11 @@ function SubjectCellComponent({ subject, onClick, onMouseEnter, onMouseLeave }: 
   )
 }
 
-// Memoize with custom comparison (only re-render if id or srsStage changes)
+// Memoize with custom comparison (only re-render if id, srsStage, or isSelected changes)
 export const KanjiCell = memo(SubjectCellComponent, (prevProps, nextProps) => {
   return (
     prevProps.subject.id === nextProps.subject.id &&
-    prevProps.subject.srsStage === nextProps.subject.srsStage
+    prevProps.subject.srsStage === nextProps.subject.srsStage &&
+    prevProps.isSelected === nextProps.isSelected
   )
 })

--- a/src/components/kanji-grid/kanji-level-section.tsx
+++ b/src/components/kanji-grid/kanji-level-section.tsx
@@ -5,11 +5,12 @@ import { KanjiCell } from './kanji-cell'
 
 interface KanjiLevelSectionProps {
   levelData: SubjectsByLevel
-  onSubjectClick: (subject: EnrichedSubject) => void
+  selectedSubjectId: number | null
+  onSubjectClick: (subject: EnrichedSubject, event: React.MouseEvent<HTMLButtonElement>) => void
   onSubjectHover: (subject: EnrichedSubject | null, event?: React.MouseEvent) => void
 }
 
-export function KanjiLevelSection({ levelData, onSubjectClick, onSubjectHover }: KanjiLevelSectionProps) {
+export function KanjiLevelSection({ levelData, selectedSubjectId, onSubjectClick, onSubjectHover }: KanjiLevelSectionProps) {
   const [isExpanded, setIsExpanded] = useState(true)
   const [isInView, setIsInView] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -75,7 +76,11 @@ export function KanjiLevelSection({ levelData, onSubjectClick, onSubjectHover }:
                 <KanjiCell
                   key={subject.id}
                   subject={subject}
-                  onClick={() => onSubjectClick(subject)}
+                  isSelected={selectedSubjectId === subject.id}
+                  onClick={(e) => {
+                    e.stopPropagation() // Prevent container click
+                    onSubjectClick(subject, e)
+                  }}
                   onMouseEnter={(e) => onSubjectHover(subject, e)}
                   onMouseLeave={() => onSubjectHover(null)}
                 />

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -67,7 +67,7 @@ export function MobileNav({ isOpen, onClose }: MobileNavProps) {
           transition: 'transform 300ms cubic-bezier(0.16, 1, 0.3, 1)',
         }}
       >
-        <div className="flex flex-col h-full">
+        <div className="flex flex-col h-full overflow-y-auto">
           {/* Header - Crimson Pro logo */}
           <div className="flex items-center justify-between p-6 border-b border-paper-300 dark:border-ink-300">
             <div className="flex items-center gap-2">

--- a/src/hooks/use-touch-device.ts
+++ b/src/hooks/use-touch-device.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Detects if the user is using a touch-primary device
+ * Uses the pointer media query which is more reliable than touch events
+ * @returns true if the primary input mechanism is touch (coarse pointer)
+ */
+export function useTouchDevice(): boolean {
+  const [isTouchDevice, setIsTouchDevice] = useState(false)
+
+  useEffect(() => {
+    // Check if pointer: coarse media query matches (touch devices)
+    const mediaQuery = window.matchMedia('(pointer: coarse)')
+
+    setIsTouchDevice(mediaQuery.matches)
+
+    // Listen for changes (e.g., when connecting/disconnecting external mouse)
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsTouchDevice(e.matches)
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  return isTouchDevice
+}


### PR DESCRIPTION
## Summary
  Fixes two critical mobile UX issues:
  1. Mobile navigation drawer overflow on shorter viewports
  2. Tooltips not accessible on touch devices (Subject Grid page)

  ## Issues Fixed

  ### 1. Mobile Nav Overflow
  **Problem**: Menu content extended past viewport bottom with no scroll on landscape mode, small devices, or large accessibility fonts.

  **Solution**: Added `overflow-y-auto` to drawer container enabling vertical scrolling.

  **File**: `src/components/layout/mobile-nav.tsx`

  ---

  ### 2. Touch Device Tooltips
  **Problem**: Subject Grid tooltips require hover, which doesn't exist on touch devices. Tapping immediately navigated to WaniKani, preventing users from seeing item details (meaning,
  reading, level, SRS stage).

  **Solution**: Implemented tap-to-select pattern:
  - **First tap**: Select cell, show tooltip (don't navigate)
  - **Second tap**: Navigate to WaniKani
  - **Tap away**: Deselect, hide tooltip
  - Desktop behavior unchanged (hover tooltip, click navigates)

  **Visual Feedback**: Selected cells display vermillion ring outline, scale up, and show elevated shadow.

  ## Implementation

  ### New Hook
  - **`useTouchDevice`** (`src/hooks/use-touch-device.ts`)
    - Detects touch-primary devices using `(pointer: coarse)` media query
    - Listens for dynamic changes (external mouse connect/disconnect)

  ### Modified Components
  - `src/components/kanji-grid/kanji-grid.tsx` - Selection state, touch-aware handlers
  - `src/components/kanji-grid/kanji-cell.tsx` - Selected visual state, event passthrough
  - `src/components/kanji-grid/kanji-level-section.tsx` - Pass selection props
  - `src/components/layout/mobile-nav.tsx` - Overflow scrolling

  ### Tooltip Positioning
  - **Touch**: Center-bottom of tapped cell
  - **Mouse**: Cursor position + 16px offset (existing)

  ## Version
  Updated to **2.4.1**
