### PR TITLE
Fix #5: don't show hidden kanjis

### DIFF
--- a/src/lib/calculations/kanji-grid.ts
+++ b/src/lib/calculations/kanji-grid.ts
@@ -182,19 +182,21 @@ export function enrichSubjectsWithSRS(
       readingType = null
     }
 
-    enrichedSubjects.push({
-      id: subject.id,
-      character,
-      characterImageUrl,
-      level: subject.level,
-      primaryMeaning,
-      primaryReading,
-      readingType,
-      srsStage,
-      srsStageName: getSRSStageName(srsStage),
-      subjectType,
-      documentUrl: subject.document_url,
-    })
+    if (subject.hidden_at == null) {
+      enrichedSubjects.push({
+        id: subject.id,
+        character,
+        characterImageUrl,
+        level: subject.level,
+        primaryMeaning,
+        primaryReading,
+        readingType,
+        srsStage,
+        srsStageName: getSRSStageName(srsStage),
+        subjectType,
+        documentUrl: subject.document_url,
+      })
+    }
   })
 
   // Sort by level, then by id


### PR DESCRIPTION
This fix this problem described in https://github.com/tyler-cartwright/wanikani-stats-tracker/issues/5 where hidden kanjis were being shown.
<img width="1109" height="1005" alt="image" src="https://github.com/user-attachments/assets/0180ce03-bf6e-4984-86e8-c9e7c61abea9" />
