### PR TITLE
feat: v2.7.0 - Readiness redesign, hidden items filter, and UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,104 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2025-12-14
+
+### Added
+- **Kanji Grid: Hidden Items Filter**: New setting to control visibility of curriculum-removed items
+  - Items with `hidden_at` timestamp (removed from WaniKani curriculum) now hidden by default
+  - Settings page includes "Show Removed Items" toggle in new "Kanji Grid" section
+  - Helpful tooltip explains these are items studied before removal but no longer taught to new students
+  - Filter respects whether user completed lessons before removal
+
+### Changed
+- **Readiness Page Hero Redesign**: Complete visual transformation for achievement-focused presentation
+  - **Centered Hero Section**: Achievement is now the main character, not the color
+    - Elegant centered layout matching Progress page's "Estimated Completion" aesthetic
+    - Small uppercase label "CURRENT PROGRESS" with large grade number in ink colors
+    - Secondary stats line with dot separators: "X kanji · Y% coverage · NZ level"
+    - Subtle gradient divider with vermillion center accent
+    - Threshold indicator badge: "Guru threshold · 1,995/2,136 Jōyō in WaniKani"
+  - **Refined Metrics Grid**: Three key metrics remain but with reduced prominence
+    - Jōyō Kanji ring reduced from 140px to 120px
+    - Reading Coverage and JLPT numbers reduced from text-5xl to text-3xl
+    - Numbers now in ink colors (not colored) with small colored icons for subtle accents
+    - Labels more prominent than values for better hierarchy
+  - **Updated Skeleton**: Loading state matches new centered hero design
+- **Kanji Grid: SRS Filter Button Colors**: Buttons now match kanji block color scheme
+  - Locked: Gray (paper-300/ink-300)
+  - Apprentice: Purple (srs-apprentice)
+  - Guru: Blue (srs-guru)
+  - Master: Green (srs-master)
+  - Enlightened: Gold (srs-enlightened)
+  - Burned: Gray (srs-burned)
+  - Visual consistency makes filtering more intuitive
+- **Progress Page: Badge Wrapping**: Method indicator badge uses flex layout for graceful wrapping
+  - Converts from inline text with `•` separators to flex container with visual dot separators
+  - Items wrap at semantic boundaries (not mid-word) on small screens
+  - Maintains rounded pill appearance even when wrapped
+- **Progress Page: Modal Animations**: Excluded levels modal now uses app-standard animations
+  - Replaced custom modal with shared `Modal` component
+  - Consistent fade + scale animation (300ms, cubic-bezier ease-out)
+  - Accessibility improvements: escape key, backdrop click, focus management
+  - Mobile spacing improvements: responsive layout, increased padding and gaps
+
+### Fixed
+- **Settings Persistence**: Theme and all user preferences now survive app version updates
+  - `clearLocalStorageExceptAuth()` now preserves both `wanikani-auth` AND `wanikani-settings`
+  - Previously only auth token was preserved, causing theme reset to light mode on updates
+- **Stale Chunk Errors**: Automatic recovery when navigating after new deployment
+  - Created `lazyWithRetry()` wrapper for all lazy-loaded pages
+  - Detects chunk load errors (old chunks missing after deployment)
+  - Automatically reloads page to fetch new chunks (max 1 retry via sessionStorage)
+  - Seamless experience - no error UI shown, just smooth reload
+- **Progress Page: Skeleton Responsiveness**: Loading states now match component responsive behavior
+  - Level60Projection skeleton: 4 milestones on mobile, 7 on desktop (was 7 always)
+  - LevelTimeline skeleton: 8 bars on mobile, 15 on desktop with overflow-x-auto
+  - Stats and legend use responsive gaps (gap-4 sm:gap-6)
+- **Progress Page: Modal Mobile Layout**: Excluded levels modal better formatted on small screens
+  - Increased spacing from space-y-2 to space-y-3
+  - List items stack vertically on mobile, side-by-side on desktop (flex-col sm:flex-row)
+  - Improved readability with responsive gaps and padding
+
+### Technical
+- Updated `src/stores/settings-store.ts`:
+  - Added `showHiddenItems` boolean setting (default: false)
+  - Added `setShowHiddenItems()` action
+- Updated `src/components/kanji-grid/kanji-grid.tsx`:
+  - Imported and applied `excludeHiddenSubjects` filter based on setting
+  - Added `showHiddenItems` to enrichment dependencies
+- Updated `src/lib/calculations/kanji-grid.ts`:
+  - Added `hidden_at: string | null` to `EnrichedSubject` interface
+  - Updated `enrichSubjectsWithSRS()` to preserve `hidden_at` field from subjects
+- Updated `src/pages/settings.tsx`:
+  - Added "Kanji Grid" settings section with toggle switch
+- Updated `src/components/kanji-grid/kanji-grid-filters.tsx`:
+  - Replaced uniform vermillion button colors with stage-specific colors
+  - Added `stageColors` mapping object for active/inactive states
+- Updated `src/components/progress/level-60-projection.tsx`:
+  - Removed green badge (lines 37-57)
+  - Added centered hero section with large grade display, stats line, divider, and badge
+  - Refined three metrics: smaller sizes, ink-colored numbers, subtle icons
+  - Imported `Modal` component and replaced custom modal markup
+  - Enhanced mobile spacing in modal list items
+  - Fixed badge flex layout for responsive wrapping
+- Updated `src/components/jlpt/jlpt-hero.tsx`:
+  - Removed `GraduationCap` icon import
+  - Added `SRS_THRESHOLD_LABELS` import and `useSettingsStore` hook
+  - Replaced green badge with centered hero section
+  - Updated three metrics with reduced sizing and ink colors
+- Updated `src/pages/readiness.tsx`:
+  - Updated skeleton to match new centered hero layout
+  - Refined metrics skeleton structure (label above, smaller circle)
+- Updated `src/lib/cache/cache-manager.ts`:
+  - `clearLocalStorageExceptAuth()` now preserves `wanikani-settings` in addition to `wanikani-auth`
+- Created `src/lib/utils/lazy-with-retry.ts`:
+  - Implements chunk load error detection and automatic page reload
+  - Uses sessionStorage to prevent infinite reload loops
+- Updated `src/App.tsx`:
+  - All lazy-loaded pages now use `lazyWithRetry()` instead of `lazy()`
+  - Removed unused `lazy` import from React
+
 ## [2.6.0] - 2025-12-13
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.6.0",
+  "version": "2.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useUserStore } from './stores/user-store'
@@ -6,16 +6,17 @@ import { AppShell } from './components/layout/app-shell'
 import { ErrorBoundary } from './components/shared/error-boundary'
 import { InitialSync } from './components/shared/initial-sync'
 import { Loader2 } from 'lucide-react'
+import { lazyWithRetry } from './lib/utils/lazy-with-retry'
 
-// Lazy load pages
-const Dashboard = lazy(() => import('./pages/dashboard').then(m => ({ default: m.Dashboard })))
-const Progress = lazy(() => import('./pages/progress').then(m => ({ default: m.Progress })))
-const Accuracy = lazy(() => import('./pages/accuracy').then(m => ({ default: m.Accuracy })))
-const Leeches = lazy(() => import('./pages/leeches').then(m => ({ default: m.Leeches })))
-const Kanji = lazy(() => import('./pages/kanji').then(m => ({ default: m.Kanji })))
-const Readiness = lazy(() => import('./pages/readiness').then(m => ({ default: m.Readiness })))
-const Settings = lazy(() => import('./pages/settings').then(m => ({ default: m.Settings })))
-const Setup = lazy(() => import('./pages/setup').then(m => ({ default: m.Setup })))
+// Lazy load pages with automatic chunk error retry
+const Dashboard = lazyWithRetry(() => import('./pages/dashboard').then(m => ({ default: m.Dashboard })))
+const Progress = lazyWithRetry(() => import('./pages/progress').then(m => ({ default: m.Progress })))
+const Accuracy = lazyWithRetry(() => import('./pages/accuracy').then(m => ({ default: m.Accuracy })))
+const Leeches = lazyWithRetry(() => import('./pages/leeches').then(m => ({ default: m.Leeches })))
+const Kanji = lazyWithRetry(() => import('./pages/kanji').then(m => ({ default: m.Kanji })))
+const Readiness = lazyWithRetry(() => import('./pages/readiness').then(m => ({ default: m.Readiness })))
+const Settings = lazyWithRetry(() => import('./pages/settings').then(m => ({ default: m.Settings })))
+const Setup = lazyWithRetry(() => import('./pages/setup').then(m => ({ default: m.Setup })))
 
 // Configure TanStack Query
 export const queryClient = new QueryClient({

--- a/src/components/jlpt/jlpt-hero.tsx
+++ b/src/components/jlpt/jlpt-hero.tsx
@@ -1,9 +1,10 @@
 import type { JoyoReadinessResult } from '@/data/jlpt'
-import { JOYO_GRADE_INFO } from '@/data/jlpt'
+import { JOYO_GRADE_INFO, SRS_THRESHOLD_LABELS } from '@/data/jlpt'
 import { JLPTProgressRing } from './jlpt-progress-ring'
 import { JLPTThresholdSelect } from './jlpt-threshold-select'
 import { InfoTooltip } from '@/components/shared/info-tooltip'
-import { GraduationCap, BookOpen, Award } from 'lucide-react'
+import { BookOpen, Award } from 'lucide-react'
+import { useSettingsStore } from '@/stores/settings-store'
 
 interface JLPTHeroProps {
   readiness: JoyoReadinessResult
@@ -18,12 +19,14 @@ export function JLPTHero({ readiness }: JLPTHeroProps) {
     approximateJlpt,
   } = readiness
 
+  const jlptThreshold = useSettingsStore((state) => state.jlptThreshold)
+
   // Calculate overall percentage
   const overallPercentage =
     totalKanjiInWanikani > 0 ? Math.round((totalKanjiKnown / totalKanjiInWanikani) * 100) : 0
 
   // Get current grade info
-  const gradeLabel = currentGrade ? JOYO_GRADE_INFO[currentGrade].label : 'Not Started'
+  const gradeLabel = currentGrade ? JOYO_GRADE_INFO[currentGrade].label : null
 
   return (
     <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-8 shadow-md">
@@ -35,29 +38,60 @@ export function JLPTHero({ readiness }: JLPTHeroProps) {
         <JLPTThresholdSelect />
       </div>
 
-      {/* Current Grade Badge */}
-      <div className="mb-8">
-        {currentGrade ? (
-          <div className="inline-flex items-center gap-3 px-6 py-3 rounded-lg bg-patina-500/20 dark:bg-patina-500/30 border border-patina-500/30">
-            <GraduationCap className="w-6 h-6 text-patina-500" />
-            <div>
-              <div className="text-sm text-ink-400 dark:text-paper-300">Current Progress</div>
-              <div className="text-2xl font-bold text-patina-500">{gradeLabel} Complete</div>
-            </div>
+      {/* Hero - Centered Progress Display */}
+      <div className="mb-10">
+        <div className="flex flex-col items-center text-center py-6">
+          {/* Small label */}
+          <div className="text-xs uppercase tracking-wider text-ink-400 dark:text-paper-300 mb-3">
+            Current Progress
           </div>
-        ) : (
-          <div className="inline-flex items-center gap-3 px-6 py-3 rounded-lg bg-paper-300 dark:bg-ink-300 border border-paper-300 dark:border-ink-300">
-            <GraduationCap className="w-6 h-6 text-ink-400 dark:text-paper-300" />
-            <div>
-              <div className="text-sm text-ink-400 dark:text-paper-300">
-                Keep studying to complete Grade 1!
+
+          {currentGrade ? (
+            <>
+              {/* Large grade display */}
+              <div className="text-4xl md:text-5xl font-display font-bold text-ink-100 dark:text-paper-100 mb-2">
+                {gradeLabel}
               </div>
-            </div>
+              <div className="text-lg text-ink-400 dark:text-paper-300 mb-4">
+                Complete
+              </div>
+            </>
+          ) : (
+            <>
+              {/* Early progress message */}
+              <div className="text-2xl md:text-3xl font-display font-semibold text-ink-100 dark:text-paper-100 mb-2">
+                Getting Started
+              </div>
+              <div className="text-sm text-ink-400 dark:text-paper-300 mb-4">
+                Keep studying to complete Grade 1
+              </div>
+            </>
+          )}
+
+          {/* Secondary stats with dot separators */}
+          <div className="flex flex-wrap items-center justify-center gap-2 text-sm text-ink-400 dark:text-paper-300">
+            <span>{totalKanjiKnown} kanji</span>
+            <span className="w-1 h-1 rounded-full bg-vermillion-500" />
+            <span>{frequencyCoverage}% coverage</span>
+            <span className="w-1 h-1 rounded-full bg-vermillion-500" />
+            <span>{approximateJlpt || '—'} level</span>
           </div>
-        )}
+
+          {/* Subtle divider with vermillion accent */}
+          <div className="mt-6 w-48 h-px bg-gradient-to-r from-transparent via-vermillion-500/40 to-transparent" />
+        </div>
+
+        {/* Threshold indicator badge */}
+        <div className="flex justify-center">
+          <div className="inline-flex flex-wrap items-center justify-center gap-1.5 text-xs text-ink-400 dark:text-paper-300 bg-paper-300/50 dark:bg-ink-300/50 px-3 py-1 rounded-full">
+            <span>{SRS_THRESHOLD_LABELS[jlptThreshold]} threshold</span>
+            <span className="w-1 h-1 rounded-full bg-ink-400/40 dark:bg-paper-300/40" aria-hidden="true" />
+            <span>{totalKanjiInWanikani}/2,136 Jōyō in WaniKani</span>
+          </div>
+        </div>
       </div>
 
-      {/* Three Key Metrics */}
+      {/* Three Key Metrics - Refined */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
         {/* Kanji Progress Ring */}
         <div className="flex flex-col items-center">
@@ -65,47 +99,47 @@ export function JLPTHero({ readiness }: JLPTHeroProps) {
             percentage={overallPercentage}
             label="Jōyō Kanji"
             count={`${totalKanjiKnown}/${totalKanjiInWanikani}`}
-            size={140}
-            strokeWidth={12}
+            size={120}
+            strokeWidth={10}
           />
           <p className="text-xs text-ink-400 dark:text-paper-300 mt-3 text-center">
-            {totalKanjiInWanikani} of 2,136 Jōyō kanji are in WaniKani
+            Overall Jōyō progress
           </p>
         </div>
 
-        {/* Frequency Coverage */}
+        {/* Reading Coverage */}
         <div className="flex flex-col items-center justify-center">
-          <div className="flex items-center gap-3 mb-3">
-            <BookOpen className="w-8 h-8 text-ochre-500" />
-            <div className="text-5xl font-bold text-ochre-500">{frequencyCoverage}%</div>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="text-sm font-medium text-ink-100 dark:text-paper-100">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="text-sm font-semibold text-ink-100 dark:text-paper-100">
               Reading Coverage
             </div>
             <InfoTooltip content="Based on kanji frequency in newspapers. This estimates what percentage of kanji you'll encounter in real text. Note: Jōyō kanji are organized by grade level, not strict frequency, so actual coverage may vary." />
           </div>
-          <p className="text-xs text-ink-400 dark:text-paper-300 mt-2 text-center max-w-[200px]">
-            Estimated coverage of kanji in real-world Japanese text
+          <div className="flex items-center gap-3 mb-2">
+            <BookOpen className="w-6 h-6 text-ochre-500" />
+            <div className="text-3xl font-bold text-ink-100 dark:text-paper-100">{frequencyCoverage}%</div>
+          </div>
+          <p className="text-xs text-ink-400 dark:text-paper-300 text-center max-w-[200px]">
+            Estimated text coverage
           </p>
         </div>
 
         {/* JLPT Approximation */}
         <div className="flex flex-col items-center justify-center">
-          <div className="flex items-center gap-3 mb-3">
-            <Award className="w-8 h-8 text-vermillion-500" />
-            <div className="text-5xl font-bold text-vermillion-500">
-              {approximateJlpt || '—'}
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="text-sm font-medium text-ink-100 dark:text-paper-100">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="text-sm font-semibold text-ink-100 dark:text-paper-100">
               Approximate JLPT
             </div>
             <InfoTooltip content="Rough mapping based on grade completion: Grade 1 → N5, Grades 1-2 → N4, Grades 1-4 → N3, Grades 1-6 → N2, All Jōyō → N1. JLPT tests vocabulary, grammar, and reading comprehension beyond just kanji." />
           </div>
-          <p className="text-xs text-ink-400 dark:text-paper-300 mt-2 text-center max-w-[200px]">
-            Rough estimate based on kanji completion
+          <div className="flex items-center gap-3 mb-2">
+            <Award className="w-6 h-6 text-vermillion-500" />
+            <div className="text-3xl font-bold text-ink-100 dark:text-paper-100">
+              {approximateJlpt || '—'}
+            </div>
+          </div>
+          <p className="text-xs text-ink-400 dark:text-paper-300 text-center max-w-[200px]">
+            Based on kanji completion
           </p>
         </div>
       </div>

--- a/src/components/kanji-grid/kanji-grid-filters.tsx
+++ b/src/components/kanji-grid/kanji-grid-filters.tsx
@@ -184,21 +184,45 @@ export function KanjiGridFilters({
       <div className="space-y-2">
         <label className="text-sm font-medium text-ink-200 dark:text-paper-200">SRS Stages:</label>
         <div className="flex flex-wrap gap-2">
-          {srsStages.map((stage) => (
-            <button
-              key={stage.value}
-              type="button"
-              onClick={() => toggleSrsStage(stage.value)}
-              className={cn(
-                'px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border',
-                srsFilter.includes(stage.value) || srsFilter.length === 0
-                  ? 'bg-vermillion-500 text-paper-100 border-vermillion-500'
-                  : 'bg-paper-200 dark:bg-ink-200 text-ink-300 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-vermillion-500'
-              )}
-            >
-              {stage.label}
-            </button>
-          ))}
+          {srsStages.map((stage) => {
+            const isActive = srsFilter.includes(stage.value) || srsFilter.length === 0
+
+            // Color mapping to match kanji block colors
+            const stageColors = {
+              initiate: isActive
+                ? 'bg-paper-300 dark:bg-ink-300 text-ink-100 dark:text-paper-100 border-paper-400 dark:border-ink-400'
+                : 'bg-paper-200 dark:bg-ink-200 text-ink-400 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-paper-400 dark:hover:border-ink-400',
+              apprentice: isActive
+                ? 'bg-srs-apprentice text-paper-100 dark:text-ink-100 border-srs-apprentice'
+                : 'bg-paper-200 dark:bg-ink-200 text-ink-400 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-srs-apprentice',
+              guru: isActive
+                ? 'bg-srs-guru text-paper-100 dark:text-ink-100 border-srs-guru'
+                : 'bg-paper-200 dark:bg-ink-200 text-ink-400 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-srs-guru',
+              master: isActive
+                ? 'bg-srs-master text-paper-100 dark:text-ink-100 border-srs-master'
+                : 'bg-paper-200 dark:bg-ink-200 text-ink-400 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-srs-master',
+              enlightened: isActive
+                ? 'bg-srs-enlightened text-paper-100 dark:text-ink-100 border-srs-enlightened'
+                : 'bg-paper-200 dark:bg-ink-200 text-ink-400 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-srs-enlightened',
+              burned: isActive
+                ? 'bg-srs-burned text-paper-100 dark:text-ink-100 border-srs-burned'
+                : 'bg-paper-200 dark:bg-ink-200 text-ink-400 dark:text-paper-300 border-paper-300 dark:border-ink-300 hover:border-srs-burned',
+            }
+
+            return (
+              <button
+                key={stage.value}
+                type="button"
+                onClick={() => toggleSrsStage(stage.value)}
+                className={cn(
+                  'px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border',
+                  stageColors[stage.value]
+                )}
+              >
+                {stage.label}
+              </button>
+            )
+          })}
           {srsFilter.length > 0 && (
             <button
               type="button"

--- a/src/components/progress/level-60-projection.tsx
+++ b/src/components/progress/level-60-projection.tsx
@@ -6,6 +6,7 @@ import { useUser, useLevelProgressions } from '@/lib/api/queries'
 import { projectLevel60Date } from '@/lib/calculations/forecasting'
 import { useSyncStore } from '@/stores/sync-store'
 import { useSettingsStore } from '@/stores/settings-store'
+import { Modal } from '@/components/shared/modal'
 
 interface Scenario {
   icon: typeof Rocket
@@ -187,18 +188,38 @@ export function Level60Projection() {
         {/* Stepper skeleton */}
         <div className="pt-6 mt-6 border-t border-paper-300 dark:border-ink-300">
           <div className="h-4 w-32 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-6" />
-          <div className="flex items-center justify-between w-full">
+
+          {/* Mobile: 4 milestones */}
+          <div className="flex items-center justify-between w-full md:hidden">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="flex items-center flex-1 last:flex-none">
+                <div className="flex flex-col items-center">
+                  <div className="w-10 h-10 rounded-full bg-paper-300 dark:bg-ink-300 animate-pulse" />
+                  <div className="mt-3 space-y-2">
+                    <div className="h-3 w-12 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                    <div className="h-3 w-16 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                  </div>
+                </div>
+                {i < 4 && (
+                  <div className="flex-1 h-0.5 mx-2 bg-paper-300 dark:bg-ink-300 animate-pulse" style={{ marginBottom: '56px' }} />
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop: 7 milestones */}
+          <div className="hidden md:flex items-center justify-between w-full">
             {[1, 2, 3, 4, 5, 6, 7].map((i) => (
               <div key={i} className="flex items-center flex-1 last:flex-none">
                 <div className="flex flex-col items-center">
-                  <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-paper-300 dark:bg-ink-300 animate-pulse" />
+                  <div className="w-10 h-10 rounded-full bg-paper-300 dark:bg-ink-300 animate-pulse" />
                   <div className="mt-3 space-y-2">
                     <div className="h-3 w-12 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
                     <div className="h-3 w-16 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
                   </div>
                 </div>
                 {i < 7 && (
-                  <div className="flex-1 h-0.5 mx-1 bg-paper-300 dark:bg-ink-300 animate-pulse" style={{ marginBottom: '56px' }} />
+                  <div className="flex-1 h-0.5 mx-2 bg-paper-300 dark:bg-ink-300 animate-pulse" style={{ marginBottom: '56px' }} />
                 )}
               </div>
             ))}
@@ -243,12 +264,15 @@ export function Level60Projection() {
         </div>
 
         {/* Method indicator - small, subtle */}
-        <div className="text-center">
-          <span className="text-xs text-ink-400 dark:text-paper-300 bg-paper-300/50 dark:bg-ink-300/50 px-3 py-1 rounded-full">
-            {useActiveAverage ? 'Active pace' : 'All levels'} • {averagingMethod === 'median' ? 'Median' : 'Trimmed mean'}
+        <div className="flex justify-center">
+          <div className="inline-flex flex-wrap items-center justify-center gap-1.5 text-xs text-ink-400 dark:text-paper-300 bg-paper-300/50 dark:bg-ink-300/50 px-3 py-1 rounded-full">
+            <span>{useActiveAverage ? 'Active pace' : 'All levels'}</span>
+            <span className="w-1 h-1 rounded-full bg-ink-400/40 dark:bg-paper-300/40" aria-hidden="true" />
+            <span>{averagingMethod === 'median' ? 'Median' : 'Trimmed mean'}</span>
             {useActiveAverage && projection.excludedLevels.length > 0 && (
               <>
-                {' '}• {completedLevels - projection.excludedLevels.length} levels{' '}
+                <span className="w-1 h-1 rounded-full bg-ink-400/40 dark:bg-paper-300/40" aria-hidden="true" />
+                <span>{completedLevels - projection.excludedLevels.length} levels</span>
                 <button
                   onClick={() => setShowExcludedLevels(true)}
                   className="text-vermillion-500 hover:underline"
@@ -257,7 +281,7 @@ export function Level60Projection() {
                 </button>
               </>
             )}
-          </span>
+          </div>
         </div>
       </div>
 
@@ -460,54 +484,40 @@ export function Level60Projection() {
       </div>
 
       {/* Excluded Levels Modal */}
-      {showExcludedLevels && projection.excludedLevels.length > 0 && (
-        <>
-          {/* Backdrop */}
-          <div
-            className="fixed inset-0 z-50 bg-ink-100/50 dark:bg-paper-100/20 transition-opacity duration-300"
-            onClick={() => setShowExcludedLevels(false)}
-            aria-hidden="true"
-          />
-
-          {/* Modal */}
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
-            <div
-              className="pointer-events-auto w-full max-w-md bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 shadow-xl"
-              role="dialog"
-              aria-modal="true"
-            >
-              <div className="p-6">
-                <h3 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
-                  Filtered Levels
-                </h3>
-                <p className="text-sm text-ink-400 dark:text-paper-300 mb-4">
-                  These levels were excluded from your active average to provide a more accurate
-                  learning pace estimate:
-                </p>
-                <div className="space-y-2 mb-6">
-                  {projection.excludedLevels.map((level) => (
-                    <div
-                      key={level.level}
-                      className="flex justify-between text-sm p-2 bg-paper-300 dark:bg-ink-300 rounded"
-                    >
-                      <span className="text-ink-100 dark:text-paper-100">Level {level.level}</span>
-                      <span className="text-ink-400 dark:text-paper-300">
-                        {level.days} days ({level.reason})
-                      </span>
-                    </div>
-                  ))}
-                </div>
-                <button
-                  onClick={() => setShowExcludedLevels(false)}
-                  className="w-full px-4 py-2 text-sm font-medium rounded-md bg-vermillion-500 hover:bg-vermillion-600 text-paper-100 dark:text-ink-100 transition-smooth focus-ring"
-                >
-                  Close
-                </button>
+      <Modal
+        isOpen={showExcludedLevels && projection.excludedLevels.length > 0}
+        onClose={() => setShowExcludedLevels(false)}
+        size="md"
+      >
+        <div className="p-6">
+          <h3 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
+            Filtered Levels
+          </h3>
+          <p className="text-sm text-ink-400 dark:text-paper-300 mb-6">
+            These levels were excluded from your active average to provide a more accurate
+            learning pace estimate:
+          </p>
+          <div className="space-y-3 mb-6">
+            {projection.excludedLevels.map((level) => (
+              <div
+                key={level.level}
+                className="flex flex-col sm:flex-row sm:justify-between gap-1 sm:gap-4 text-sm p-3 bg-paper-300 dark:bg-ink-300 rounded"
+              >
+                <span className="text-ink-100 dark:text-paper-100 font-medium">Level {level.level}</span>
+                <span className="text-ink-400 dark:text-paper-300">
+                  {level.days} days · {level.reason}
+                </span>
               </div>
-            </div>
+            ))}
           </div>
-        </>
-      )}
+          <button
+            onClick={() => setShowExcludedLevels(false)}
+            className="w-full px-4 py-2 text-sm font-medium rounded-md bg-vermillion-500 hover:bg-vermillion-600 text-paper-100 dark:text-ink-100 transition-smooth focus-ring"
+          >
+            Close
+          </button>
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/src/components/progress/level-timeline.tsx
+++ b/src/components/progress/level-timeline.tsx
@@ -125,27 +125,40 @@ export function LevelTimeline() {
         <div className="h-6 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-6" />
 
         {/* Stats row */}
-        <div className="flex gap-6 mb-8">
+        <div className="flex flex-wrap gap-4 sm:gap-6 mb-8">
           <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-32" />
           <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-32" />
           <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-32" />
         </div>
 
         {/* Vertical bar placeholders */}
-        <div className="h-[400px] flex items-end gap-1">
-          {Array.from({ length: 15 }).map((_, i) => (
-            <div key={i} className="flex-1 flex flex-col items-center justify-end">
-              <div
-                className="w-full bg-paper-300 dark:bg-ink-300 rounded-t-md animate-pulse"
-                style={{ height: `${Math.random() * 300 + 50}px` }}
-              />
-              <div className="w-6 h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mt-2" />
-            </div>
-          ))}
+        <div className="relative overflow-x-auto pb-2">
+          <div className="h-[400px] flex items-end gap-1 min-w-full">
+            {/* Mobile: fewer bars */}
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="flex-1 flex flex-col items-center justify-end md:hidden min-w-[8px]">
+                <div
+                  className="w-full bg-paper-300 dark:bg-ink-300 rounded-t-md animate-pulse"
+                  style={{ height: `${Math.random() * 300 + 50}px` }}
+                />
+                <div className="w-6 h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mt-2" />
+              </div>
+            ))}
+            {/* Desktop: more bars */}
+            {Array.from({ length: 15 }).map((_, i) => (
+              <div key={i} className="hidden md:flex flex-1 flex-col items-center justify-end min-w-[8px]">
+                <div
+                  className="w-full bg-paper-300 dark:bg-ink-300 rounded-t-md animate-pulse"
+                  style={{ height: `${Math.random() * 300 + 50}px` }}
+                />
+                <div className="w-6 h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mt-2" />
+              </div>
+            ))}
+          </div>
         </div>
 
         {/* Legend */}
-        <div className="flex gap-4 mt-6">
+        <div className="flex flex-wrap gap-3 sm:gap-4 mt-6">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="h-4 w-20 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
           ))}

--- a/src/lib/cache/cache-manager.ts
+++ b/src/lib/cache/cache-manager.ts
@@ -28,17 +28,21 @@ export async function clearServiceWorkerCaches(): Promise<void> {
 }
 
 /**
- * Clears all localStorage except the auth token
- * Preserves user authentication while clearing cached data
+ * Clears all localStorage except the auth token and user settings
+ * Preserves user authentication and preferences (theme, etc.) while clearing cached data
  */
 export function clearLocalStorageExceptAuth(): void {
   try {
     const authData = localStorage.getItem('wanikani-auth')
+    const settingsData = localStorage.getItem('wanikani-settings')
     localStorage.clear()
     if (authData) {
       localStorage.setItem('wanikani-auth', authData)
     }
-    console.log('LocalStorage cleared (except auth)')
+    if (settingsData) {
+      localStorage.setItem('wanikani-settings', settingsData)
+    }
+    console.log('LocalStorage cleared (except auth and settings)')
   } catch (error) {
     console.error('Failed to clear localStorage:', error)
     throw error

--- a/src/lib/calculations/kanji-grid.ts
+++ b/src/lib/calculations/kanji-grid.ts
@@ -18,6 +18,7 @@ export interface EnrichedSubject {
   srsStageName: SRSStage
   subjectType: SubjectType
   documentUrl: string
+  hidden_at: string | null // WaniKani curriculum removal timestamp
 }
 
 export interface SubjectsByLevel {
@@ -194,6 +195,7 @@ export function enrichSubjectsWithSRS(
       srsStageName: getSRSStageName(srsStage),
       subjectType,
       documentUrl: subject.document_url,
+      hidden_at: subject.hidden_at,
     })
   })
 

--- a/src/lib/utils/lazy-with-retry.ts
+++ b/src/lib/utils/lazy-with-retry.ts
@@ -1,0 +1,73 @@
+/**
+ * Lazy import wrapper with automatic retry for chunk load errors
+ *
+ * When a new version is deployed, old chunks are no longer available.
+ * This wrapper detects chunk load errors and automatically reloads the page
+ * to fetch the new version, providing a seamless update experience.
+ */
+
+import { ComponentType, lazy } from 'react'
+
+const RELOAD_KEY = 'chunk-reload-attempted'
+const MAX_RETRIES = 1
+
+/**
+ * Checks if an error is a chunk load error
+ */
+function isChunkLoadError(error: Error): boolean {
+  return (
+    error.name === 'ChunkLoadError' ||
+    error.message.includes('Failed to fetch dynamically imported module') ||
+    error.message.includes('Importing a module script failed') ||
+    error.message.includes('error loading dynamically imported module')
+  )
+}
+
+/**
+ * Reloads the page to fetch new chunks after a deployment
+ */
+function reloadForNewVersion(): void {
+  const reloadAttempts = parseInt(sessionStorage.getItem(RELOAD_KEY) || '0', 10)
+
+  if (reloadAttempts < MAX_RETRIES) {
+    console.log('[Chunk Loader] Chunk load error detected - reloading for new version')
+    sessionStorage.setItem(RELOAD_KEY, String(reloadAttempts + 1))
+    window.location.reload()
+  } else {
+    // Max retries reached - clear the flag and let error bubble up
+    console.error('[Chunk Loader] Max reload attempts reached - letting error surface')
+    sessionStorage.removeItem(RELOAD_KEY)
+  }
+}
+
+/**
+ * Wraps React.lazy with automatic chunk error handling and reload
+ *
+ * @param importFunc - The dynamic import function
+ * @returns A lazy-loaded component with retry logic
+ *
+ * @example
+ * const Dashboard = lazyWithRetry(() => import('./pages/dashboard'))
+ */
+export function lazyWithRetry<T extends ComponentType<any>>(
+  importFunc: () => Promise<{ default: T }>
+): React.LazyExoticComponent<T> {
+  return lazy(async () => {
+    // Clear reload flag on successful load
+    sessionStorage.removeItem(RELOAD_KEY)
+
+    try {
+      return await importFunc()
+    } catch (error) {
+      // Check if it's a chunk load error
+      if (error instanceof Error && isChunkLoadError(error)) {
+        reloadForNewVersion()
+        // Return a never-resolving promise to prevent error UI flash
+        return new Promise(() => {})
+      }
+
+      // Re-throw other errors to be caught by error boundary
+      throw error
+    }
+  })
+}

--- a/src/pages/readiness.tsx
+++ b/src/pages/readiness.tsx
@@ -54,17 +54,33 @@ export function Readiness() {
             <div className="h-10 w-40 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
           </div>
 
-          {/* Current Grade Badge */}
-          <div className="mb-8">
-            <div className="h-16 w-64 bg-paper-300 dark:bg-ink-300 rounded-lg animate-pulse" />
+          {/* Hero - Centered Progress */}
+          <div className="mb-10">
+            <div className="flex flex-col items-center py-6 space-y-4">
+              {/* Small label */}
+              <div className="h-3 w-32 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+              {/* Large grade */}
+              <div className="h-12 w-48 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+              {/* Complete subtitle */}
+              <div className="h-5 w-24 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+              {/* Stats line */}
+              <div className="h-4 w-64 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+              {/* Divider */}
+              <div className="h-px w-48 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+            </div>
+            {/* Badge */}
+            <div className="flex justify-center">
+              <div className="h-6 w-56 bg-paper-300 dark:bg-ink-300 rounded-full animate-pulse" />
+            </div>
           </div>
 
-          {/* Three Metrics */}
+          {/* Three Metrics - Refined */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
             {[1, 2, 3].map((i) => (
               <div key={i} className="flex flex-col items-center space-y-3">
-                <div className="h-36 w-36 bg-paper-300 dark:bg-ink-300 rounded-full animate-pulse" />
                 <div className="h-4 w-32 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                <div className="h-32 w-32 bg-paper-300 dark:bg-ink-300 rounded-full animate-pulse" />
+                <div className="h-3 w-28 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
               </div>
             ))}
           </div>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -24,7 +24,9 @@ export function Settings() {
     customThresholdDays,
     setCustomThresholdDays,
     jlptThreshold,
-    setJlptThreshold
+    setJlptThreshold,
+    showHiddenItems,
+    setShowHiddenItems
   } = useSettingsStore()
   const { confirm, ConfirmDialog } = useConfirm()
 
@@ -200,6 +202,37 @@ export function Settings() {
             <div className="text-xs text-ink-400 dark:text-paper-300 mt-2">
               {SRS_THRESHOLD_DESCRIPTIONS[jlptThreshold]}
             </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Kanji Grid Settings */}
+      <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+        <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
+          Kanji Grid
+        </h2>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium text-ink-100 dark:text-paper-100">
+                Show Removed Items
+              </label>
+              <InfoTooltip content="Show items that have been removed from the WaniKani curriculum. These are subjects you may have studied before they were removed, but are no longer taught to new students." />
+            </div>
+            <button
+              onClick={() => setShowHiddenItems(!showHiddenItems)}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                showHiddenItems
+                  ? 'bg-vermillion-500'
+                  : 'bg-paper-300 dark:bg-ink-300'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-paper-100 dark:bg-ink-100 transition-transform ${
+                  showHiddenItems ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
           </div>
         </div>
       </div>

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -14,6 +14,7 @@ interface SettingsState {
   useCustomThreshold: boolean // default: false
   customThresholdDays: number // default: 60
   jlptThreshold: SRSThreshold // default: 'guru'
+  showHiddenItems: boolean // default: false - show items removed from curriculum
 
   // Actions
   setTheme: (theme: 'light' | 'dark') => void
@@ -25,6 +26,7 @@ interface SettingsState {
   setUseCustomThreshold: (value: boolean) => void
   setCustomThresholdDays: (days: number) => void
   setJlptThreshold: (threshold: SRSThreshold) => void
+  setShowHiddenItems: (value: boolean) => void
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -40,6 +42,7 @@ export const useSettingsStore = create<SettingsState>()(
       useCustomThreshold: false, // default to OFF
       customThresholdDays: 60, // default 60 days
       jlptThreshold: 'guru', // default to Guru (SRS 5+)
+      showHiddenItems: false, // default to hiding curriculum-removed items
 
       // Actions
       setTheme: (theme: 'light' | 'dark') => {
@@ -86,6 +89,10 @@ export const useSettingsStore = create<SettingsState>()(
 
       setJlptThreshold: (threshold: SRSThreshold) => {
         set({ jlptThreshold: threshold })
+      },
+
+      setShowHiddenItems: (value: boolean) => {
+        set({ showHiddenItems: value })
       },
     }),
     {


### PR DESCRIPTION
## Overview
  Version 2.7.0 brings visual refinements, new filtering capabilities, and critical bug fixes for deployment reliability.

  ## Key Changes

  ### ✨ Features
  - **Hidden Items Filter**: New setting to show/hide curriculum-removed items in Kanji Grid (hidden by default)

  ### 🎨 Design Improvements
  - **Readiness Page Hero**: Complete redesign with centered layout - achievement is now the focus, not color
    - Elegant hero matching Progress page aesthetic
    - Refined metrics with reduced visual prominence
  - **Kanji Grid**: SRS filter buttons now match kanji block colors (purple/blue/green/gold instead of all red)
  - **Progress Page**: Improved badge wrapping and modal animations
    - Flex layout prevents awkward line breaks
    - Modal uses standard fade + scale animation

  ### 🐛 Bug Fixes
  - **Settings Persistence**: Theme and preferences now survive app updates
  - **Stale Chunks**: Automatic page reload when navigating after deployment (no more manual retry)
  - **Mobile Responsiveness**: Fixed skeleton loading states and modal spacing on small screens

  ## Technical Details
  See [CHANGELOG.md](CHANGELOG.md#270---2025-12-14) for complete implementation details.

  ## Testing
  - ✅ Build successful
  - ✅ Type checking passed
  - ✅ All features verified