### PR TITLE
feat: v2.8.0 - Progress page enhancements with Knowledge Stability, Burn Velocity, and Milestones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,86 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2025-12-14
+
+### Fixed
+- **Accuracy Page Skeleton Loading**: All accuracy components now show proper structured skeletons instead of loading text
+  - **Accuracy Distribution**: Shows label/range/stats placeholders for each bucket with progress bars and footer
+  - **Accuracy by Level (Time Heatmap)**: Shows title, level bars, stats, and insight box placeholders instead of "Loading accuracy by level..." text
+  - **Type Breakdown**: Shows label/accuracy/count row with progress bar for each type (radicals, kanji, vocabulary)
+  - Consistent with loading patterns across the rest of the application
+
+## [2.8.0] - 2025-12-14
+
+### Added
+- **Progress Page Enhancement**: Three new comprehensive progress tracking components
+  - **Knowledge Stability**: Monitor how well learned items "stick" in memory
+    - Large stability ratio percentage showing solid vs fragile items
+    - Visual breakdown bar (solid items in green, fragile items in red)
+    - Breakdown by subject type (radicals, kanji, vocabulary)
+    - "At-risk items" modal with configurable display limits (10/25/50/All)
+    - Fragile items: those that passed Guru but fell back to Apprentice
+    - Solid items: those that passed Guru and remain at Guru+ stages
+    - Excludes burned items (permanently stable)
+  - **Burn Velocity**: Track burn progress and trends over time
+    - Circular progress ring showing total burn percentage
+    - Burn statistics for 7/30/90 day periods with daily rates
+    - Trend indicators (up/down/stable) comparing current vs previous periods
+    - Projected "all burned" completion date based on current velocity
+    - Remaining items counter
+  - **Milestone Timeline**: Visual achievement journey with badges
+    - Guru milestones: First Guru, 100, 500, 1000, 2500, All Guru (based on `passed_at`)
+    - Burn milestones: First Burn, 100, 500, 1000, 2500, 5000, All Burned (based on `burned_at`)
+    - Level milestones: 10, 20, 30, 40, 50, 60
+    - Grid and timeline view toggle
+    - Achievement badges with tooltips showing dates and descriptions
+    - Next milestone preview with progress bar
+    - Grayed out badges for upcoming achievements
+
+### Fixed
+- **Knowledge Stability Calculation**: Fixed logic to properly identify passed items
+  - Now uses `passed_at` timestamp instead of `passed` boolean (consistent with rest of codebase)
+  - Correctly counts items that have reached Guru stage
+  - Properly tracks items that fell back from Guru to Apprentice
+- **Level Milestone Tracking**: Fixed achievement detection for completed levels
+  - Now uses `currentLevel > target` instead of relying on `passed_at` in progressions
+  - Correctly shows levels as achieved when user has passed them (e.g., level 14 user shows level 10 as achieved)
+  - Eliminates negative "X to go" display for already-completed levels
+
+### Technical
+- Added `src/lib/calculations/knowledge-stability.ts`:
+  - `calculateKnowledgeStability()` - Main stability calculation
+  - `getAtRiskItems()` - Identifies and sorts fragile items by SRS stage
+  - TypeScript interfaces: `KnowledgeStability`, `AtRiskItem`, `TypeBreakdown`
+- Added `src/lib/calculations/burn-velocity.ts`:
+  - `calculateBurnVelocity()` - Main velocity calculation
+  - `calculateBurnPeriod()` - Period-based burn counting
+  - `calculateTrend()` - Trend comparison algorithm (>10% = up/down)
+  - TypeScript interfaces: `BurnVelocity`, `BurnPeriod`
+- Added `src/lib/calculations/milestones.ts`:
+  - `calculateMilestones()` - Main milestone orchestration
+  - `getBurnMilestones()` - Burn achievement tracking
+  - `getGuruMilestones()` - Guru achievement tracking (using `passed_at`)
+  - `getLevelMilestones()` - Level completion tracking
+  - TypeScript interfaces: `Milestone`, `MilestoneTimeline`
+- Added `src/components/progress/knowledge-stability.tsx`:
+  - Main component with stability display and modal
+  - Configurable at-risk item display limits
+  - Loading skeleton matching component layout
+- Added `src/components/progress/burn-velocity.tsx`:
+  - `ProgressRing` SVG component for circular progress
+  - `VelocityStat` component for period statistics
+  - Loading skeleton with responsive design
+- Added `src/components/progress/milestone-timeline.tsx`:
+  - `MilestoneBadge` component with tooltips
+  - `MilestoneTimelineItem` for chronological list view
+  - `NextMilestonePreview` with progress bar
+  - Grid/timeline view toggle
+  - Loading skeleton
+- Updated `src/pages/progress.tsx`:
+  - New component order: Level60Projection → KnowledgeStability → BurnVelocity → MilestoneTimeline → LevelTimeline
+  - All components maintain consistent spacing and responsive design
+
 ## [2.7.0] - 2025-12-14
 
 ### Added
@@ -629,6 +709,10 @@ WaniTrack v2.0.0 - Complete WaniKani statistics tracker and analytics platform.
 
 ## Version History Summary
 
+- **2.8.1** (Dec 14, 2025) - Fixed Accuracy Distribution skeleton loading state
+- **2.8.0** (Dec 14, 2025) - Progress page enhancement: Knowledge Stability, Burn Velocity, Milestone Timeline
+- **2.7.0** (Dec 14, 2025) - Readiness hero redesign, hidden items filter, UX improvements
+- **2.6.0** (Dec 13, 2025) - Progress page redesign with journey milestones and level history chart
 - **2.5.2** (Dec 9, 2025) - Radical image contrast matches text/SRS colors across themes
 - **2.5.1** (Dec 9, 2025) - Readiness skeleton during sync; fallback radical SVGs
 - **2.5.0** (Dec 8, 2025) - Exam Readiness pivot to Jōyō system, new metrics/UI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.7.0",
+  "version": "2.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/accuracy/accuracy-distribution.tsx
+++ b/src/components/accuracy/accuracy-distribution.tsx
@@ -56,11 +56,33 @@ export function AccuracyDistribution() {
   if (isLoading || isSyncing) {
     return (
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+        {/* Title */}
         <div className="h-6 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-6" />
+
+        {/* Buckets */}
         <div className="space-y-4">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-16 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+            <div key={i}>
+              {/* Label and stats row */}
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <div className="h-4 w-16 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                  <div className="h-3 w-12 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                </div>
+                <div className="flex items-center gap-3">
+                  <div className="h-4 w-8 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                  <div className="h-3 w-10 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                </div>
+              </div>
+              {/* Progress bar */}
+              <div className="h-3 bg-paper-300 dark:bg-ink-300 rounded-full animate-pulse" />
+            </div>
           ))}
+        </div>
+
+        {/* Footer */}
+        <div className="mt-6 pt-4 border-t border-paper-300 dark:border-ink-300">
+          <div className="h-4 w-32 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mx-auto" />
         </div>
       </div>
     )

--- a/src/components/accuracy/time-heatmap.tsx
+++ b/src/components/accuracy/time-heatmap.tsx
@@ -93,9 +93,41 @@ export function TimeHeatmap() {
   if (isLoading) {
     return (
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
-        <div className="flex items-center justify-center py-12">
-          <div className="text-sm text-ink-400 dark:text-paper-300">
-            Loading accuracy by level...
+        {/* Title and level count */}
+        <div className="flex items-center justify-between mb-6">
+          <div className="h-6 w-40 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+          <div className="h-4 w-20 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+        </div>
+
+        {/* Bar chart */}
+        <div className="space-y-2 mb-6">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <div className="w-12 h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+              <div className="flex-1">
+                <div
+                  className="h-8 bg-paper-300 dark:bg-ink-300 rounded-md animate-pulse"
+                  style={{ width: `${60 + Math.random() * 35}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Stats */}
+        <div className="flex flex-wrap gap-6 mb-6">
+          <div className="h-4 w-32 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+          <div className="h-4 w-32 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+        </div>
+
+        {/* Insight box */}
+        <div className="p-4 bg-paper-300/50 dark:bg-ink-300/50 rounded-lg">
+          <div className="flex gap-3">
+            <div className="w-5 h-5 bg-paper-300 dark:bg-ink-300 rounded animate-pulse flex-shrink-0" />
+            <div className="flex-1 space-y-2">
+              <div className="h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-full" />
+              <div className="h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-3/4" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/accuracy/type-breakdown.tsx
+++ b/src/components/accuracy/type-breakdown.tsx
@@ -47,12 +47,23 @@ export function TypeBreakdown() {
   if (isLoading) {
     return (
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+        {/* Title */}
         <div className="h-6 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-6" />
+
+        {/* Type sections */}
         <div className="space-y-6">
           {[1, 2, 3].map((i) => (
             <div key={i} className="space-y-2">
-              <div className="h-6 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
-              <div className="h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+              {/* Label, accuracy, count row */}
+              <div className="flex items-center justify-between">
+                <div className="h-5 w-20 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                <div className="flex items-center gap-4">
+                  <div className="h-7 w-12 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                  <div className="h-4 w-16 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+                </div>
+              </div>
+              {/* Progress bar */}
+              <div className="h-3 bg-paper-300 dark:bg-ink-300 rounded-full animate-pulse" />
             </div>
           ))}
         </div>

--- a/src/components/progress/burn-velocity.tsx
+++ b/src/components/progress/burn-velocity.tsx
@@ -1,0 +1,198 @@
+import { useMemo } from 'react'
+import { format } from 'date-fns'
+import { Flame, TrendingUp, TrendingDown, Minus } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import { useAssignments, useSubjects } from '@/lib/api/queries'
+import { useSyncStore } from '@/stores/sync-store'
+import { calculateBurnVelocity, type BurnPeriod } from '@/lib/calculations/burn-velocity'
+
+interface VelocityStatProps {
+  period: string
+  data: BurnPeriod
+  trend?: 'up' | 'down' | 'stable'
+}
+
+function VelocityStat({ period, data, trend }: VelocityStatProps) {
+  const TrendIcon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : Minus
+
+  return (
+    <div className="bg-paper-300/50 dark:bg-ink-300/50 rounded-lg p-4">
+      <div className="text-xs text-ink-400 dark:text-paper-300 mb-2">{period}</div>
+      <div className="flex items-end justify-between">
+        <div>
+          <div className="text-2xl font-bold text-ink-100 dark:text-paper-100">
+            {data.count.toLocaleString()}
+          </div>
+          <div className="text-xs text-ink-400 dark:text-paper-300">
+            ~{data.rate.toFixed(1)}/day
+          </div>
+        </div>
+        {trend && (
+          <TrendIcon
+            className={cn(
+              'w-5 h-5',
+              trend === 'up' && 'text-patina-600 dark:text-patina-500',
+              trend === 'down' && 'text-vermillion-500 dark:text-vermillion-400',
+              trend === 'stable' && 'text-ink-400 dark:text-paper-300'
+            )}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ProgressRing({ percentage }: { percentage: number }) {
+  const radius = 45
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference - (percentage / 100) * circumference
+
+  return (
+    <div className="relative w-32 h-32 flex-shrink-0">
+      <svg className="w-full h-full -rotate-90" viewBox="0 0 100 100">
+        {/* Background ring */}
+        <circle
+          cx="50"
+          cy="50"
+          r={radius}
+          className="stroke-paper-300 dark:stroke-ink-300"
+          strokeWidth="8"
+          fill="none"
+        />
+        {/* Progress ring */}
+        <circle
+          cx="50"
+          cy="50"
+          r={radius}
+          className="stroke-vermillion-500 dark:stroke-vermillion-400 transition-all duration-slow"
+          strokeWidth="8"
+          fill="none"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+        />
+      </svg>
+      {/* Percentage text */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="text-2xl font-bold text-ink-100 dark:text-paper-100">
+          {percentage.toFixed(0)}%
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export function BurnVelocity() {
+  const { data: assignments, isLoading: assignmentsLoading } = useAssignments()
+  const { data: subjects, isLoading: subjectsLoading } = useSubjects()
+  const isSyncing = useSyncStore((state) => state.isSyncing)
+
+  const isLoading = assignmentsLoading || subjectsLoading || isSyncing
+
+  const velocity = useMemo(() => {
+    if (!assignments || !subjects) return null
+    return calculateBurnVelocity(assignments, subjects)
+  }, [assignments, subjects])
+
+  if (isLoading) {
+    return (
+      <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+        {/* Title */}
+        <div className="h-6 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-8" />
+
+        {/* Hero section */}
+        <div className="flex items-center gap-6 mb-8">
+          <div className="w-32 h-32 bg-paper-300 dark:bg-ink-300 rounded-full animate-pulse flex-shrink-0" />
+          <div className="flex-1 space-y-3">
+            <div className="h-12 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-1/2" />
+            <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-3/4" />
+          </div>
+        </div>
+
+        {/* Velocity stats grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="bg-paper-300/50 dark:bg-ink-300/50 rounded-lg p-4">
+              <div className="h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-16 mb-3" />
+              <div className="h-8 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-20 mb-2" />
+              <div className="h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-24" />
+            </div>
+          ))}
+        </div>
+
+        {/* Projection */}
+        <div className="border-t border-paper-300 dark:border-ink-300 pt-4">
+          <div className="h-3 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-48 mb-2" />
+          <div className="h-6 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-32" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!velocity) {
+    return null
+  }
+
+  return (
+    <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+      <div className="flex items-center gap-2 mb-8">
+        <Flame className="w-5 h-5 text-vermillion-500" />
+        <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100">
+          Burn Progress
+        </h2>
+      </div>
+
+      {/* Hero: Progress ring and stats */}
+      <div className="flex flex-col sm:flex-row items-center gap-6 mb-8">
+        <ProgressRing percentage={velocity.burnPercentage} />
+        <div>
+          <div className="text-3xl md:text-4xl font-display font-bold text-ink-100 dark:text-paper-100">
+            {velocity.totalBurned.toLocaleString()}
+          </div>
+          <div className="text-sm text-ink-400 dark:text-paper-300 mt-1">
+            of {velocity.totalItems.toLocaleString()} items burned
+          </div>
+          {velocity.totalBurned > 0 && (
+            <div className="text-xs text-ink-400 dark:text-paper-300 mt-2 flex items-center gap-1">
+              <span className="w-1.5 h-1.5 rounded-full bg-vermillion-500" />
+              {(velocity.totalItems - velocity.totalBurned).toLocaleString()} remaining
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Velocity stats: 7/30/90 day rates with trends */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <VelocityStat period="Last 7 days" data={velocity.last7Days} trend={velocity.trend7Days} />
+        <VelocityStat period="Last 30 days" data={velocity.last30Days} trend={velocity.trend30Days} />
+        <VelocityStat period="Last 90 days" data={velocity.last90Days} />
+      </div>
+
+      {/* Projection */}
+      {velocity.projectedBurnDate && velocity.daysToComplete && (
+        <div className="border-t border-paper-300 dark:border-ink-300 pt-4">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div>
+              <div className="text-xs text-ink-400 dark:text-paper-300 mb-1">
+                At current pace, all items burned by:
+              </div>
+              <div className="text-lg font-semibold text-ink-100 dark:text-paper-100">
+                {format(velocity.projectedBurnDate, 'MMMM yyyy')}
+              </div>
+            </div>
+            <div className="text-xs text-ink-400 dark:text-paper-300 bg-paper-300/50 dark:bg-ink-300/50 px-3 py-1.5 rounded-full self-start sm:self-center">
+              ~{velocity.daysToComplete.toLocaleString()} days remaining
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* No burns yet message */}
+      {velocity.totalBurned === 0 && (
+        <div className="text-center py-4 text-sm text-ink-400 dark:text-paper-300">
+          No items burned yet. Keep reviewing to reach Enlightened!
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/progress/knowledge-stability.tsx
+++ b/src/components/progress/knowledge-stability.tsx
@@ -1,0 +1,237 @@
+import { useState, useMemo } from 'react'
+import { format } from 'date-fns'
+import { Shield, AlertTriangle } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import { useAssignments, useSubjects } from '@/lib/api/queries'
+import { useSyncStore } from '@/stores/sync-store'
+import { calculateKnowledgeStability } from '@/lib/calculations/knowledge-stability'
+import { Modal } from '@/components/shared/modal'
+
+export function KnowledgeStability() {
+  const { data: assignments, isLoading: assignmentsLoading } = useAssignments()
+  const { data: subjects, isLoading: subjectsLoading } = useSubjects()
+  const isSyncing = useSyncStore((state) => state.isSyncing)
+  const [showAtRisk, setShowAtRisk] = useState(false)
+  const [atRiskLimit, setAtRiskLimit] = useState<10 | 25 | 50 | 'all'>(25)
+
+  const isLoading = assignmentsLoading || subjectsLoading || isSyncing
+
+  const stability = useMemo(() => {
+    if (!assignments || !subjects) return null
+    return calculateKnowledgeStability(assignments, subjects)
+  }, [assignments, subjects])
+
+  if (isLoading) {
+    return (
+      <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+        {/* Title */}
+        <div className="h-6 bg-paper-300 dark:bg-ink-300 rounded animate-pulse mb-8" />
+
+        {/* Hero metric */}
+        <div className="flex items-center gap-4 mb-6">
+          <div className="h-16 w-24 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+          <div className="flex-1">
+            <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-3/4" />
+          </div>
+        </div>
+
+        {/* Progress bar */}
+        <div className="mb-4">
+          <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded-full animate-pulse mb-2" />
+          <div className="flex justify-between">
+            <div className="h-3 w-20 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+            <div className="h-3 w-20 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+          </div>
+        </div>
+
+        {/* At-risk button */}
+        <div className="border-t border-paper-300 dark:border-ink-300 pt-4 mt-6">
+          <div className="h-10 bg-paper-300 dark:bg-ink-300 rounded animate-pulse" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!stability) {
+    return null
+  }
+
+  const solidPercent = stability.totalPassed > 0 ? (stability.solidItems / stability.totalPassed) * 100 : 0
+  const fragilePercent = stability.totalPassed > 0 ? (stability.fragileItems / stability.totalPassed) * 100 : 0
+  const stabilityPercent = Math.round(stability.stabilityRatio * 100)
+
+  return (
+    <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+      <div className="flex items-center gap-2 mb-8">
+        <Shield className="w-5 h-5 text-patina-500" />
+        <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100">
+          Knowledge Stability
+        </h2>
+      </div>
+
+      {/* Main metric: Stability ratio as percentage */}
+      <div className="flex items-center gap-4 mb-6">
+        <div className="text-4xl md:text-5xl font-display font-bold text-ink-100 dark:text-paper-100">
+          {stabilityPercent}%
+        </div>
+        <div className="text-sm text-ink-400 dark:text-paper-300">
+          of passed items remain at Guru or above
+        </div>
+      </div>
+
+      {/* Visual breakdown: Solid vs Fragile bar */}
+      <div className="mb-4">
+        <div className="flex gap-1 h-4 rounded-full overflow-hidden bg-paper-300 dark:bg-ink-300">
+          {solidPercent > 0 && (
+            <div
+              className="bg-patina-500 dark:bg-patina-400 transition-all"
+              style={{ width: `${solidPercent}%` }}
+            />
+          )}
+          {fragilePercent > 0 && (
+            <div
+              className="bg-vermillion-500 dark:bg-vermillion-400 transition-all"
+              style={{ width: `${fragilePercent}%` }}
+            />
+          )}
+        </div>
+        <div className="flex justify-between text-xs mt-2">
+          <span className="text-patina-600 dark:text-patina-500 font-medium">
+            {stability.solidItems.toLocaleString()} solid
+          </span>
+          <span className="text-vermillion-500 dark:text-vermillion-400 font-medium">
+            {stability.fragileItems.toLocaleString()} fragile
+          </span>
+        </div>
+      </div>
+
+      {/* Stats summary */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+        <div className="bg-paper-300/50 dark:bg-ink-300/50 rounded-lg p-3">
+          <div className="text-xs text-ink-400 dark:text-paper-300 mb-1">Radicals</div>
+          <div className="text-sm font-semibold text-ink-100 dark:text-paper-100">
+            {stability.byType.radical.total > 0
+              ? Math.round((stability.byType.radical.solid / stability.byType.radical.total) * 100)
+              : 0}
+            % stable
+          </div>
+        </div>
+        <div className="bg-paper-300/50 dark:bg-ink-300/50 rounded-lg p-3">
+          <div className="text-xs text-ink-400 dark:text-paper-300 mb-1">Kanji</div>
+          <div className="text-sm font-semibold text-ink-100 dark:text-paper-100">
+            {stability.byType.kanji.total > 0
+              ? Math.round((stability.byType.kanji.solid / stability.byType.kanji.total) * 100)
+              : 0}
+            % stable
+          </div>
+        </div>
+        <div className="bg-paper-300/50 dark:bg-ink-300/50 rounded-lg p-3">
+          <div className="text-xs text-ink-400 dark:text-paper-300 mb-1">Vocabulary</div>
+          <div className="text-sm font-semibold text-ink-100 dark:text-paper-100">
+            {stability.byType.vocabulary.total > 0
+              ? Math.round((stability.byType.vocabulary.solid / stability.byType.vocabulary.total) * 100)
+              : 0}
+            % stable
+          </div>
+        </div>
+      </div>
+
+      {/* At-risk items preview */}
+      {stability.atRiskItems.length > 0 && (
+        <div className="border-t border-paper-300 dark:border-ink-300 pt-4">
+          <button
+            onClick={() => setShowAtRisk(true)}
+            className="w-full flex items-center justify-between px-4 py-3 rounded-md bg-vermillion-500/10 dark:bg-vermillion-400/10 hover:bg-vermillion-500/20 dark:hover:bg-vermillion-400/20 transition-smooth group"
+          >
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="w-4 h-4 text-vermillion-500 dark:text-vermillion-400" />
+              <span className="text-sm font-medium text-ink-100 dark:text-paper-100">
+                View {stability.atRiskItems.length.toLocaleString()} at-risk items
+              </span>
+            </div>
+            <span className="text-xs text-ink-400 dark:text-paper-300 group-hover:text-ink-100 dark:group-hover:text-paper-100">
+              →
+            </span>
+          </button>
+        </div>
+      )}
+
+      {/* Modal for at-risk items list */}
+      <Modal isOpen={showAtRisk} onClose={() => setShowAtRisk(false)} size="lg">
+        <div className="p-6">
+          <div className="flex items-center gap-2 mb-4">
+            <AlertTriangle className="w-5 h-5 text-vermillion-500 dark:text-vermillion-400" />
+            <h3 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100">
+              At-Risk Items
+            </h3>
+          </div>
+          <p className="text-sm text-ink-400 dark:text-paper-300 mb-6">
+            These items passed Guru but have fallen back. They're most likely to become leeches.
+          </p>
+
+          {/* Limit selector */}
+          <div className="flex gap-2 mb-4">
+            <span className="text-xs text-ink-400 dark:text-paper-300 self-center mr-2">Show:</span>
+            <div className="flex gap-1 bg-paper-300 dark:bg-ink-300 rounded-lg p-1">
+              {([10, 25, 50, 'all'] as const).map((limit) => (
+                <button
+                  key={limit}
+                  onClick={() => setAtRiskLimit(limit)}
+                  className={cn(
+                    'px-3 py-1 rounded-md text-xs font-medium transition-smooth',
+                    atRiskLimit === limit
+                      ? 'bg-paper-200 dark:bg-ink-200 text-ink-100 dark:text-paper-100 shadow-sm'
+                      : 'text-ink-400 dark:text-paper-300 hover:text-ink-100 dark:hover:text-paper-100'
+                  )}
+                >
+                  {limit === 'all' ? 'All' : limit}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Items list */}
+          <div className="max-h-[400px] overflow-y-auto space-y-2">
+            {stability.atRiskItems
+              .slice(0, atRiskLimit === 'all' ? undefined : atRiskLimit)
+              .map((item) => (
+                <div
+                  key={item.subjectId}
+                  className="flex items-center justify-between p-3 bg-paper-300/50 dark:bg-ink-300/50 rounded-lg hover:bg-paper-300 dark:hover:bg-ink-300 transition-smooth"
+                >
+                  <div className="flex items-center gap-3">
+                    {item.character && (
+                      <div className="text-2xl font-japanese">{item.character}</div>
+                    )}
+                    <div>
+                      <div className="text-sm font-medium text-ink-100 dark:text-paper-100">
+                        {item.meaning}
+                      </div>
+                      <div className="text-xs text-ink-400 dark:text-paper-300">
+                        Level {item.level} · {item.subjectType}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-xs font-medium text-vermillion-500 dark:text-vermillion-400">
+                      SRS {item.currentSrsStage}
+                    </div>
+                    <div className="text-xs text-ink-400 dark:text-paper-300">
+                      Passed {format(item.passedAt, 'MMM yyyy')}
+                    </div>
+                  </div>
+                </div>
+              ))}
+          </div>
+
+          <button
+            onClick={() => setShowAtRisk(false)}
+            className="w-full mt-6 px-4 py-2 text-sm font-medium rounded-md bg-vermillion-500 hover:bg-vermillion-600 text-paper-100 dark:text-ink-100 transition-smooth focus-ring"
+          >
+            Close
+          </button>
+        </div>
+      </Modal>
+    </div>
+  )
+}

--- a/src/components/progress/milestone-timeline.tsx
+++ b/src/components/progress/milestone-timeline.tsx
@@ -1,0 +1,287 @@
+import { useState, useMemo } from 'react'
+import { format } from 'date-fns'
+import { Flame, Star, Trophy, Award, Sparkles, Grid3x3, List } from 'lucide-react'
+import { cn } from '@/lib/utils/cn'
+import { useAssignments, useLevelProgressions, useSubjects, useUser } from '@/lib/api/queries'
+import { useSyncStore } from '@/stores/sync-store'
+import { calculateMilestones, type Milestone } from '@/lib/calculations/milestones'
+
+interface MilestoneBadgeProps {
+  milestone: Milestone
+  isAchieved: boolean
+}
+
+function MilestoneBadge({ milestone, isAchieved }: MilestoneBadgeProps) {
+  const Icon = getIcon(milestone.icon)
+  const progress = milestone.target > 0 ? (milestone.current / milestone.target) * 100 : 0
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center p-3 rounded-lg transition-smooth group relative',
+        isAchieved
+          ? 'bg-paper-300/50 dark:bg-ink-300/50 hover:bg-paper-300 dark:hover:bg-ink-300'
+          : 'bg-paper-300/20 dark:bg-ink-300/20 opacity-60'
+      )}
+    >
+      {/* Icon */}
+      <div
+        className={cn(
+          'w-12 h-12 rounded-full flex items-center justify-center mb-2 transition-smooth',
+          isAchieved
+            ? 'bg-vermillion-500/20 dark:bg-vermillion-400/20'
+            : 'bg-paper-300 dark:bg-ink-300'
+        )}
+      >
+        <Icon
+          className={cn(
+            'w-6 h-6 transition-smooth',
+            isAchieved
+              ? 'text-vermillion-500 dark:text-vermillion-400'
+              : 'text-ink-400 dark:text-paper-400'
+          )}
+        />
+      </div>
+
+      {/* Label */}
+      <div
+        className={cn(
+          'text-xs font-medium text-center',
+          isAchieved
+            ? 'text-ink-100 dark:text-paper-100'
+            : 'text-ink-400 dark:text-paper-300'
+        )}
+      >
+        {milestone.label}
+      </div>
+
+      {/* Progress for upcoming milestones */}
+      {!isAchieved && progress > 0 && (
+        <div className="text-xs text-ink-400 dark:text-paper-300 mt-1">
+          {Math.round(progress)}%
+        </div>
+      )}
+
+      {/* Tooltip on hover */}
+      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+        <div className="bg-ink-100 dark:bg-paper-100 text-paper-100 dark:text-ink-100 text-xs px-3 py-2 rounded whitespace-nowrap shadow-lg">
+          {milestone.description}
+          {isAchieved && milestone.achievedAt && (
+            <div className="text-ink-400 dark:text-paper-300 mt-1">
+              {format(milestone.achievedAt, 'MMM d, yyyy')}
+            </div>
+          )}
+          {!isAchieved && (
+            <div className="text-ink-400 dark:text-paper-300 mt-1">
+              {milestone.current.toLocaleString()} / {milestone.target.toLocaleString()}
+            </div>
+          )}
+          {/* Arrow */}
+          <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-ink-100 dark:border-t-paper-100" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MilestoneTimelineItem({ milestone }: { milestone: Milestone }) {
+  const Icon = getIcon(milestone.icon)
+
+  return (
+    <div className="flex items-start gap-4 p-4 bg-paper-300/50 dark:bg-ink-300/50 rounded-lg">
+      <div className="w-10 h-10 rounded-full bg-vermillion-500/20 dark:bg-vermillion-400/20 flex items-center justify-center flex-shrink-0">
+        <Icon className="w-5 h-5 text-vermillion-500 dark:text-vermillion-400" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-ink-100 dark:text-paper-100">{milestone.label}</div>
+        <div className="text-sm text-ink-400 dark:text-paper-300 mt-0.5">
+          {milestone.description}
+        </div>
+      </div>
+      {milestone.achievedAt && (
+        <div className="text-xs text-ink-400 dark:text-paper-300 flex-shrink-0">
+          {format(milestone.achievedAt, 'MMM d, yyyy')}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function NextMilestonePreview({ milestone }: { milestone: Milestone }) {
+  const Icon = getIcon(milestone.icon)
+  const progress = milestone.target > 0 ? (milestone.current / milestone.target) * 100 : 0
+  const remaining = milestone.target - milestone.current
+
+  return (
+    <div className="flex items-center gap-4 p-4 bg-paper-300/50 dark:bg-ink-300/50 rounded-lg mt-2">
+      <div className="w-10 h-10 rounded-full bg-vermillion-500/10 dark:bg-vermillion-400/10 flex items-center justify-center flex-shrink-0">
+        <Icon className="w-5 h-5 text-vermillion-500 dark:text-vermillion-400" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-ink-100 dark:text-paper-100 mb-2">
+          {milestone.label}
+        </div>
+        {/* Progress bar */}
+        <div className="relative h-2 bg-paper-300 dark:bg-ink-300 rounded-full overflow-hidden">
+          <div
+            className="absolute inset-y-0 left-0 bg-vermillion-500 dark:bg-vermillion-400 transition-all"
+            style={{ width: `${Math.min(progress, 100)}%` }}
+          />
+        </div>
+        <div className="text-xs text-ink-400 dark:text-paper-300 mt-1">
+          {remaining.toLocaleString()} more to go
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function getIcon(iconName: string) {
+  const icons: Record<string, typeof Flame> = {
+    Flame,
+    Star,
+    Trophy,
+    Award,
+    Sparkles,
+  }
+  return icons[iconName] || Trophy
+}
+
+export function MilestoneTimeline() {
+  const { data: assignments, isLoading: assignmentsLoading } = useAssignments()
+  const { data: levelProgressions, isLoading: progressionsLoading } = useLevelProgressions()
+  const { data: subjects, isLoading: subjectsLoading } = useSubjects()
+  const { data: user, isLoading: userLoading } = useUser()
+  const isSyncing = useSyncStore((state) => state.isSyncing)
+  const [viewMode, setViewMode] = useState<'grid' | 'timeline'>('grid')
+
+  const isLoading = assignmentsLoading || progressionsLoading || subjectsLoading || userLoading || isSyncing
+
+  const milestones = useMemo(() => {
+    if (!assignments || !levelProgressions || !subjects || !user) return null
+    return calculateMilestones(assignments, levelProgressions, subjects, user.level)
+  }, [assignments, levelProgressions, subjects, user])
+
+  if (isLoading) {
+    return (
+      <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div className="h-6 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-32" />
+          <div className="h-8 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-20" />
+        </div>
+
+        {/* Stats summary */}
+        <div className="flex gap-4 mb-6">
+          <div className="h-12 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-20" />
+          <div className="h-4 bg-paper-300 dark:bg-ink-300 rounded animate-pulse w-40 self-center" />
+        </div>
+
+        {/* Grid */}
+        <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-3">
+          {Array.from({ length: 16 }).map((_, i) => (
+            <div key={i} className="aspect-square bg-paper-300 dark:bg-ink-300 rounded-lg animate-pulse" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (!milestones) {
+    return null
+  }
+
+  // Combine all milestones for grid view, sort by achievement and then by target
+  const allMilestones = [...milestones.achieved, ...milestones.upcoming].sort((a, b) => {
+    // Sort by type first (burn, srs, level)
+    if (a.type !== b.type) {
+      const typeOrder = { burn: 0, srs: 1, level: 2 }
+      return typeOrder[a.type] - typeOrder[b.type]
+    }
+    // Then by target
+    return a.target - b.target
+  })
+
+  return (
+    <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+      {/* Header with view toggle */}
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100">
+          Achievements
+        </h2>
+        <div className="flex gap-1 bg-paper-300 dark:bg-ink-300 rounded-lg p-1">
+          <button
+            onClick={() => setViewMode('grid')}
+            className={cn(
+              'p-2 rounded-md transition-smooth',
+              viewMode === 'grid'
+                ? 'bg-paper-200 dark:bg-ink-200 text-ink-100 dark:text-paper-100 shadow-sm'
+                : 'text-ink-400 dark:text-paper-300 hover:text-ink-100 dark:hover:text-paper-100'
+            )}
+            aria-label="Grid view"
+          >
+            <Grid3x3 className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => setViewMode('timeline')}
+            className={cn(
+              'p-2 rounded-md transition-smooth',
+              viewMode === 'timeline'
+                ? 'bg-paper-200 dark:bg-ink-200 text-ink-100 dark:text-paper-100 shadow-sm'
+                : 'text-ink-400 dark:text-paper-300 hover:text-ink-100 dark:hover:text-paper-100'
+            )}
+            aria-label="Timeline view"
+          >
+            <List className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Stats summary */}
+      <div className="flex gap-4 mb-6">
+        <div className="text-3xl font-display font-bold text-ink-100 dark:text-paper-100">
+          {milestones.stats.totalAchieved}
+        </div>
+        <div className="text-sm text-ink-400 dark:text-paper-300 self-center">
+          milestones achieved
+        </div>
+      </div>
+
+      {/* Grid view: Achievement badges */}
+      {viewMode === 'grid' && (
+        <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-3">
+          {allMilestones.map((milestone) => (
+            <MilestoneBadge
+              key={milestone.id}
+              milestone={milestone}
+              isAchieved={milestone.isAchieved}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Timeline view: Chronological list */}
+      {viewMode === 'timeline' && (
+        <div className="space-y-3">
+          {milestones.achieved.length > 0 ? (
+            milestones.achieved.map((milestone) => (
+              <MilestoneTimelineItem key={milestone.id} milestone={milestone} />
+            ))
+          ) : (
+            <div className="text-center py-8 text-sm text-ink-400 dark:text-paper-300">
+              No milestones achieved yet. Keep learning!
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Next milestone teaser */}
+      {milestones.stats.nextMilestone && (
+        <div className="mt-6 border-t border-paper-300 dark:border-ink-300 pt-4">
+          <div className="text-sm text-ink-400 dark:text-paper-300 mb-2">Next milestone:</div>
+          <NextMilestonePreview milestone={milestones.stats.nextMilestone} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/calculations/burn-velocity.ts
+++ b/src/lib/calculations/burn-velocity.ts
@@ -1,0 +1,126 @@
+// Burn Velocity Calculations
+import { subDays, isWithinInterval, addDays } from 'date-fns'
+import type { Assignment, Subject } from '@/lib/api/types'
+
+export interface BurnPeriod {
+  count: number // Number of burns in this period
+  rate: number // Burns per day
+}
+
+export interface BurnVelocity {
+  totalBurned: number
+  totalItems: number
+  burnPercentage: number
+
+  // Period-based velocity
+  last7Days: BurnPeriod
+  last30Days: BurnPeriod
+  last90Days: BurnPeriod
+
+  // Trend comparison (current vs previous period)
+  trend7Days: 'up' | 'down' | 'stable'
+  trend30Days: 'up' | 'down' | 'stable'
+
+  // Projection
+  projectedBurnDate: Date | null // When all items will be burned at current pace
+  daysToComplete: number | null
+}
+
+/**
+ * Calculate burn velocity metrics
+ */
+export function calculateBurnVelocity(
+  assignments: Assignment[],
+  subjects: Array<Subject & { id: number }>
+): BurnVelocity {
+  const now = new Date()
+
+  // Count total items and burned items
+  const totalItems = subjects.filter((s) => !s.hidden_at).length
+  const burnedAssignments = assignments.filter((a) => a.burned_at && !a.hidden)
+
+  const totalBurned = burnedAssignments.length
+  const burnPercentage = totalItems > 0 ? (totalBurned / totalItems) * 100 : 0
+
+  // Calculate burns for different periods
+  const last7Days = calculateBurnPeriod(burnedAssignments, now, 7)
+  const last30Days = calculateBurnPeriod(burnedAssignments, now, 30)
+  const last90Days = calculateBurnPeriod(burnedAssignments, now, 90)
+
+  // Calculate previous periods for trend comparison
+  const prev7Days = calculateBurnPeriod(burnedAssignments, subDays(now, 7), 7)
+  const prev30Days = calculateBurnPeriod(burnedAssignments, subDays(now, 30), 30)
+
+  // Determine trends
+  const trend7Days = calculateTrend(last7Days.rate, prev7Days.rate)
+  const trend30Days = calculateTrend(last30Days.rate, prev30Days.rate)
+
+  // Project completion date based on 30-day average
+  let projectedBurnDate: Date | null = null
+  let daysToComplete: number | null = null
+
+  if (last30Days.rate > 0) {
+    const remaining = totalItems - totalBurned
+    daysToComplete = Math.ceil(remaining / last30Days.rate)
+    projectedBurnDate = addDays(now, daysToComplete)
+  }
+
+  return {
+    totalBurned,
+    totalItems,
+    burnPercentage,
+    last7Days,
+    last30Days,
+    last90Days,
+    trend7Days,
+    trend30Days,
+    projectedBurnDate,
+    daysToComplete,
+  }
+}
+
+/**
+ * Calculate burn count and rate for a specific period
+ */
+function calculateBurnPeriod(
+  burnedAssignments: Assignment[],
+  endDate: Date,
+  days: number
+): BurnPeriod {
+  const startDate = subDays(endDate, days)
+
+  const count = burnedAssignments.filter((a) => {
+    if (!a.burned_at) return false
+    const burnedDate = new Date(a.burned_at)
+    return isWithinInterval(burnedDate, { start: startDate, end: endDate })
+  }).length
+
+  const rate = count / days
+
+  return { count, rate }
+}
+
+/**
+ * Calculate trend by comparing current rate to previous rate
+ * >10% change = up/down, otherwise stable
+ */
+function calculateTrend(
+  currentRate: number,
+  previousRate: number
+): 'up' | 'down' | 'stable' {
+  // If both rates are very low (< 0.1 per day), consider stable
+  if (currentRate < 0.1 && previousRate < 0.1) {
+    return 'stable'
+  }
+
+  // If previous rate was zero, any current rate is "up"
+  if (previousRate === 0) {
+    return currentRate > 0 ? 'up' : 'stable'
+  }
+
+  const percentChange = ((currentRate - previousRate) / previousRate) * 100
+
+  if (percentChange > 10) return 'up'
+  if (percentChange < -10) return 'down'
+  return 'stable'
+}

--- a/src/lib/calculations/knowledge-stability.ts
+++ b/src/lib/calculations/knowledge-stability.ts
@@ -1,0 +1,170 @@
+// Knowledge Stability Calculations
+import type { Assignment, Subject } from '@/lib/api/types'
+
+export interface AtRiskItem {
+  subjectId: number
+  character: string | null
+  meaning: string
+  level: number
+  subjectType: 'radical' | 'kanji' | 'vocabulary' | 'kana_vocabulary'
+  currentSrsStage: number
+  passedAt: Date
+}
+
+export interface TypeBreakdown {
+  solid: number
+  fragile: number
+  total: number
+}
+
+export interface KnowledgeStability {
+  // Core metrics
+  totalPassed: number // Items that ever reached Guru (passed === true)
+  solidItems: number // Passed and currently at Guru+ (srs_stage >= 5)
+  fragileItems: number // Passed but fell below Guru (srs_stage < 5)
+  stabilityRatio: number // solid / totalPassed (0-1)
+
+  // At-risk items list
+  atRiskItems: AtRiskItem[]
+
+  // Breakdown by subject type
+  byType: {
+    radical: TypeBreakdown
+    kanji: TypeBreakdown
+    vocabulary: TypeBreakdown
+  }
+}
+
+/**
+ * Calculate knowledge stability metrics
+ * An item is "passed" if it ever reached Guru (stage 5+)
+ * An item is "solid" if it's currently at Guru+ AND was passed
+ * An item is "fragile" if it was passed but fell below Guru
+ */
+export function calculateKnowledgeStability(
+  assignments: Assignment[],
+  subjects: Array<Subject & { id: number }>
+): KnowledgeStability {
+  // Initialize counters
+  let totalPassed = 0
+  let solidItems = 0
+  let fragileItems = 0
+
+  const byType = {
+    radical: { solid: 0, fragile: 0, total: 0 },
+    kanji: { solid: 0, fragile: 0, total: 0 },
+    vocabulary: { solid: 0, fragile: 0, total: 0 },
+  }
+
+  const fragileAssignments: Assignment[] = []
+
+  // Analyze each assignment
+  for (const assignment of assignments) {
+    // Skip hidden items and items that were never started
+    if (assignment.hidden || !assignment.started_at) continue
+
+    // Only count items that have passed (reached Guru at some point)
+    if (!assignment.passed_at) continue
+
+    // Skip burned items (stage 9) - they're permanently stable
+    if (assignment.srs_stage === 9) continue
+
+    totalPassed++
+
+    // Determine if currently solid or fragile
+    // Solid: Currently at Guru/Master/Enlightened (5-8)
+    // Fragile: Currently at Apprentice (1-4) - fell back from Guru
+    const isSolid = assignment.srs_stage >= 5 && assignment.srs_stage <= 8
+    const isFragile = assignment.srs_stage >= 1 && assignment.srs_stage <= 4
+
+    if (isSolid) {
+      solidItems++
+    } else if (isFragile) {
+      fragileItems++
+      fragileAssignments.push(assignment)
+    }
+
+    // Count by type (only count radicals, kanji, vocabulary - skip kana_vocabulary for now)
+    const subjectType = assignment.subject_type
+    if (subjectType === 'radical') {
+      byType.radical.total++
+      if (isSolid) byType.radical.solid++
+      if (isFragile) byType.radical.fragile++
+    } else if (subjectType === 'kanji') {
+      byType.kanji.total++
+      if (isSolid) byType.kanji.solid++
+      if (isFragile) byType.kanji.fragile++
+    } else if (subjectType === 'vocabulary') {
+      byType.vocabulary.total++
+      if (isSolid) byType.vocabulary.solid++
+      if (isFragile) byType.vocabulary.fragile++
+    }
+  }
+
+  // Calculate stability ratio (handle division by zero)
+  const stabilityRatio = totalPassed > 0 ? solidItems / totalPassed : 1
+
+  // Get detailed info for at-risk (fragile) items
+  const atRiskItems = getAtRiskItems(fragileAssignments, subjects)
+
+  return {
+    totalPassed,
+    solidItems,
+    fragileItems,
+    stabilityRatio,
+    atRiskItems,
+    byType,
+  }
+}
+
+/**
+ * Get detailed information for fragile items
+ * Sorted by SRS stage (lowest first - most at risk)
+ */
+function getAtRiskItems(
+  fragileAssignments: Assignment[],
+  subjects: Array<Subject & { id: number }>
+): AtRiskItem[] {
+  // Create a map for quick subject lookup
+  const subjectMap = new Map<number, Subject & { id: number }>()
+  for (const subject of subjects) {
+    subjectMap.set(subject.id, subject)
+  }
+
+  const atRiskItems: AtRiskItem[] = []
+
+  for (const assignment of fragileAssignments) {
+    const subject = subjectMap.get(assignment.subject_id)
+    if (!subject || !assignment.passed_at) continue
+
+    // Get character based on subject type
+    let character: string | null = null
+    if ('characters' in subject && subject.characters) {
+      character = subject.characters
+    }
+
+    // Get primary meaning
+    const primaryMeaning = subject.meanings.find((m) => m.primary)
+    const meaning = primaryMeaning ? primaryMeaning.meaning : subject.meanings[0]?.meaning || 'Unknown'
+
+    atRiskItems.push({
+      subjectId: subject.id,
+      character,
+      meaning,
+      level: subject.level,
+      subjectType: assignment.subject_type,
+      currentSrsStage: assignment.srs_stage,
+      passedAt: new Date(assignment.passed_at),
+    })
+  }
+
+  // Sort by SRS stage (lowest first), then by passed_at (oldest first)
+  atRiskItems.sort((a, b) => {
+    if (a.currentSrsStage !== b.currentSrsStage) {
+      return a.currentSrsStage - b.currentSrsStage
+    }
+    return a.passedAt.getTime() - b.passedAt.getTime()
+  })
+
+  return atRiskItems
+}

--- a/src/lib/calculations/milestones.ts
+++ b/src/lib/calculations/milestones.ts
@@ -1,0 +1,189 @@
+// Milestone Calculations
+import type { Assignment, LevelProgression } from '@/lib/api/types'
+
+export interface Milestone {
+  id: string
+  type: 'burn' | 'level' | 'srs'
+  label: string
+  description: string
+  icon: string // Lucide icon name
+  achievedAt: Date | null
+  target: number
+  current: number
+  isAchieved: boolean
+}
+
+export interface MilestoneTimeline {
+  achieved: Milestone[]
+  upcoming: Milestone[]
+  stats: {
+    totalAchieved: number
+    nextMilestone: Milestone | null
+  }
+}
+
+/**
+ * Calculate all milestones based on assignments and level progressions
+ */
+export function calculateMilestones(
+  assignments: Assignment[],
+  levelProgressions: LevelProgression[],
+  subjects: Array<{ id: number; hidden_at: string | null }>,
+  currentLevel: number
+): MilestoneTimeline {
+  const milestones: Milestone[] = []
+
+  // Get burn milestones
+  milestones.push(...getBurnMilestones(assignments, subjects))
+
+  // Get Guru milestones (based on passed_at)
+  milestones.push(...getGuruMilestones(assignments, subjects))
+
+  // Get level milestones
+  milestones.push(...getLevelMilestones(levelProgressions, currentLevel))
+
+  // Separate achieved and upcoming
+  const achieved = milestones
+    .filter((m) => m.isAchieved)
+    .sort((a, b) => {
+      if (!a.achievedAt || !b.achievedAt) return 0
+      return b.achievedAt.getTime() - a.achievedAt.getTime()
+    })
+
+  const upcoming = milestones
+    .filter((m) => !m.isAchieved)
+    .sort((a, b) => {
+      // Sort by how close they are to completion (percentage)
+      const aProgress = a.target > 0 ? a.current / a.target : 0
+      const bProgress = b.target > 0 ? b.current / b.target : 0
+      return bProgress - aProgress
+    })
+
+  return {
+    achieved,
+    upcoming,
+    stats: {
+      totalAchieved: achieved.length,
+      nextMilestone: upcoming[0] || null,
+    },
+  }
+}
+
+/**
+ * Get burn-related milestones
+ */
+function getBurnMilestones(
+  assignments: Assignment[],
+  subjects: Array<{ id: number; hidden_at: string | null }>
+): Milestone[] {
+  const burned = assignments
+    .filter((a) => a.burned_at && !a.hidden)
+    .map((a) => ({
+      id: a.subject_id,
+      burnedAt: new Date(a.burned_at!),
+    }))
+    .sort((a, b) => a.burnedAt.getTime() - b.burnedAt.getTime())
+
+  const currentBurned = burned.length
+  const totalAvailable = subjects.filter((s) => !s.hidden_at).length
+
+  const targets = [1, 100, 500, 1000, 2500, 5000, totalAvailable]
+
+  return targets.map((target) => {
+    const isAchieved = currentBurned >= target
+    const achievedItem = burned[target - 1] // Get the Nth burned item (0-indexed)
+
+    return {
+      id: `burn-${target}`,
+      type: 'burn' as const,
+      label: target === 1 ? 'First Burn' : target === totalAvailable ? 'All Burned' : `${target.toLocaleString()} Burns`,
+      description:
+        target === 1
+          ? 'Burned your first item'
+          : target === totalAvailable
+          ? 'Burned all available items'
+          : `Burned ${target.toLocaleString()} items`,
+      icon: 'Flame',
+      achievedAt: isAchieved && achievedItem ? achievedItem.burnedAt : null,
+      target,
+      current: currentBurned,
+      isAchieved,
+    }
+  })
+}
+
+/**
+ * Get Guru-related milestones
+ * Based on passed_at (items that ever reached Guru)
+ */
+function getGuruMilestones(
+  assignments: Assignment[],
+  subjects: Array<{ id: number; hidden_at: string | null }>
+): Milestone[] {
+  // Get all items that have passed Guru (have passed_at timestamp)
+  const passed = assignments
+    .filter((a) => a.passed_at && !a.hidden)
+    .map((a) => ({
+      id: a.subject_id,
+      passedAt: new Date(a.passed_at!),
+    }))
+    .sort((a, b) => a.passedAt.getTime() - b.passedAt.getTime())
+
+  const currentPassed = passed.length
+  const totalAvailable = subjects.filter((s) => !s.hidden_at).length
+
+  const targets = [1, 100, 500, 1000, 2500, totalAvailable]
+
+  return targets.map((target) => {
+    const isAchieved = currentPassed >= target
+    const achievedItem = passed[target - 1] // Get the Nth passed item (0-indexed)
+
+    return {
+      id: `guru-${target}`,
+      type: 'srs' as const,
+      label: target === 1 ? 'First Guru' : target === totalAvailable ? 'All Guru' : `${target.toLocaleString()} Guru`,
+      description:
+        target === 1
+          ? 'Reached Guru on your first item'
+          : target === totalAvailable
+          ? 'Reached Guru on all available items'
+          : `Reached Guru on ${target.toLocaleString()} items`,
+      icon: 'Star',
+      achievedAt: isAchieved && achievedItem ? achievedItem.passedAt : null,
+      target,
+      current: currentPassed,
+      isAchieved,
+    }
+  })
+}
+
+/**
+ * Get level-related milestones
+ */
+function getLevelMilestones(
+  levelProgressions: LevelProgression[],
+  currentLevel: number
+): Milestone[] {
+  const targets = [10, 20, 30, 40, 50, 60]
+
+  return targets.map((target) => {
+    const progression = levelProgressions.find((p) => p.level === target)
+    const isAchieved = currentLevel > target
+    const achievedAt = progression?.passed_at ? new Date(progression.passed_at) : null
+
+    return {
+      id: `level-${target}`,
+      type: 'level' as const,
+      label: `Level ${target}`,
+      description:
+        target === 60
+          ? 'Reached maximum level'
+          : `Completed level ${target}`,
+      icon: 'Trophy',
+      achievedAt,
+      target,
+      current: currentLevel,
+      isAchieved,
+    }
+  })
+}

--- a/src/pages/progress.tsx
+++ b/src/pages/progress.tsx
@@ -1,11 +1,23 @@
 import { LevelTimeline } from '@/components/progress/level-timeline'
 import { Level60Projection } from '@/components/progress/level-60-projection'
+import { BurnVelocity } from '@/components/progress/burn-velocity'
+import { KnowledgeStability } from '@/components/progress/knowledge-stability'
+import { MilestoneTimeline } from '@/components/progress/milestone-timeline'
 
 export function Progress() {
   return (
     <div className="space-y-8">
       {/* Level 60 Projection */}
       <Level60Projection />
+
+      {/* Knowledge Stability */}
+      <KnowledgeStability />
+
+      {/* Burn Velocity */}
+      <BurnVelocity />
+
+      {/* Milestone Timeline */}
+      <MilestoneTimeline />
 
       {/* Level Timeline */}
       <LevelTimeline />


### PR DESCRIPTION
## Summary
  Major enhancement to the Progress page with three new comprehensive tracking components, plus skeleton loading improvements for the Accuracy page.

  ## What's New (v2.8.0)

  ### 🎯 Knowledge Stability
  Monitor how well learned items "stick" in memory
  - Large stability ratio percentage showing solid vs fragile items
  - Visual breakdown bar (solid in green, fragile in red)
  - Breakdown by subject type (radicals, kanji, vocabulary)
  - "At-risk items" modal with configurable display limits (10/25/50/All)
  - **Solid items**: Passed Guru and remain at Guru+ stages
  - **Fragile items**: Passed Guru but fell back to Apprentice (warning signs for potential leeches)

  ### 🔥 Burn Velocity
  Track burn progress and trends over time
  - Circular progress ring showing total burn percentage
  - Burn statistics for 7/30/90 day periods with daily rates
  - Trend indicators (↑↓−) comparing current vs previous periods
  - Projected "all burned" completion date based on current velocity
  - Remaining items counter

  ### 🏆 Milestone Timeline
  Visual achievement journey with badges
  - **Guru milestones**: First Guru, 100, 500, 1000, 2500, All Guru (based on `passed_at`)
  - **Burn milestones**: First Burn, 100, 500, 1000, 2500, 5000, All Burned (based on `burned_at`)
  - **Level milestones**: 10, 20, 30, 40, 50, 60
  - Grid and timeline view toggle
  - Achievement badges with tooltips showing dates and descriptions
  - Next milestone preview with progress bar
  - Grayed out badges for upcoming achievements

  ## Fixes (v2.8.0)

  ### Knowledge Stability Calculation
  - Now uses `passed_at` timestamp instead of `passed` boolean (consistent with rest of codebase)
  - Correctly identifies items that have reached Guru stage
  - Properly tracks items that fell back from Guru to Apprentice

  ### Level Milestone Tracking
  - Now uses `currentLevel > target` instead of relying on `passed_at` in progressions
  - Correctly shows levels as achieved when user has passed them
  - Eliminates negative "X to go" display for already-completed levels

  ## Fixes (v2.8.1)

  ### Accuracy Page Skeleton Loading
  All accuracy components now show proper structured skeletons instead of loading text:
  - **Accuracy Distribution**: Label/range/stats placeholders with progress bars and footer
  - **Accuracy by Level**: Title, level bars, stats, and insight box (replaced "Loading..." text)
  - **Type Breakdown**: Label/accuracy/count rows with progress bars for each type