### PR TITLE
fix: Mobile responsiveness, navigation overflow, and footer positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.2] - 2025-12-23
+
+### Fixed
+- **Mobile Responsiveness: Navigation Detection**: Fixed mobile navigation not appearing on mobile devices and Chrome DevTools responsive mode
+  - Replaced unreliable `resize` event listener with `matchMedia` API for responsive breakpoint detection
+  - Mobile navigation now correctly responds to Chrome DevTools device dropdown changes
+  - Fixed mobile orientation changes not triggering navigation updates on iOS/Android
+  - Improved PWA viewport change detection
+- **Desktop Navigation: Overflow on Mid-Sized Screens**: Fixed horizontal scrollbar appearing on iPad Pro and screens at lower desktop breakpoint
+  - Increased mobile/desktop breakpoint from 1024px (lg) to 1280px (xl)
+  - Desktop navigation now only appears when there's sufficient space for all 7 nav items
+  - iPad Pro portrait (1024px) now correctly shows mobile navigation
+- **Footer Positioning: Floating on Short Pages**: Fixed footer hovering above bottom of viewport on pages with minimal content
+  - Implemented flexbox sticky footer pattern
+  - Footer now anchors to bottom of screen on short pages (Dashboard, Setup)
+  - Footer still flows naturally after content on long pages
+
+### Technical
+- Updated `src/hooks/use-mobile.ts`:
+  - Replaced `window.addEventListener('resize', ...)` with `window.matchMedia('(max-width: 1279px)').addEventListener('change', ...)` for reliable breakpoint detection (lines 11-26)
+  - Changed breakpoint from 1024px (lg) to 1280px (xl) (lines 5, 14)
+  - Added helper function `getIsMobile()` for computing initial state (lines 3-6)
+- Updated `src/components/layout/app-shell.tsx`:
+  - Added `flex flex-col` to root div for sticky footer layout (line 19)
+  - Replaced `min-h-[calc(100vh-200px)]` with `flex-1` on main element for flexible content area (line 53)
+
 ## [2.12.1] - 2025-12-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.12.1",
+  "version": "2.12.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -16,7 +16,7 @@ export function AppShell({ children }: AppShellProps) {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
 
   return (
-    <div className="min-h-screen bg-paper-100 dark:bg-ink-100">
+    <div className="min-h-screen flex flex-col bg-paper-100 dark:bg-ink-100">
       {isMobile ? (
         <>
           {/* Mobile Header with Hamburger */}
@@ -50,7 +50,7 @@ export function AppShell({ children }: AppShellProps) {
       )}
 
       {/* Page Content - generous padding, max-width for readability */}
-      <main className="container mx-auto px-8 py-12 max-w-6xl min-h-[calc(100vh-200px)]">
+      <main className="flex-1 container mx-auto px-8 py-12 max-w-6xl">
         {children}
       </main>
 

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,17 +1,29 @@
 import { useState, useEffect } from 'react'
 
+function getIsMobile(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.innerWidth < 1280 // xl breakpoint
+}
+
 export function useMobile() {
-  const [isMobile, setIsMobile] = useState(false)
+  const [isMobile, setIsMobile] = useState(getIsMobile)
 
   useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 1024) // lg breakpoint
+    // Use matchMedia for more reliable breakpoint detection
+    // This fires on Chrome DevTools device changes, orientation changes, etc.
+    const mediaQuery = window.matchMedia('(max-width: 1279px)')
+
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(e.matches)
     }
 
-    checkMobile()
-    window.addEventListener('resize', checkMobile)
+    // Set initial value from media query
+    handleChange(mediaQuery)
 
-    return () => window.removeEventListener('resize', checkMobile)
+    // Listen for changes - works better than resize events
+    mediaQuery.addEventListener('change', handleChange)
+
+    return () => mediaQuery.removeEventListener('change', handleChange)
   }, [])
 
   return isMobile


### PR DESCRIPTION
## Summary
  Fixes three critical UX issues affecting mobile devices, mid-sized screens, and pages with minimal content.

  ## Issues Fixed

  ### 1. Mobile Navigation Not Responding to Viewport Changes
  - **Problem**: Desktop navigation showing on mobile devices and Chrome DevTools responsive mode
  - **Root cause**: `resize` event listener doesn't fire reliably on DevTools device dropdown changes or mobile orientation changes
  - **Solution**: Replaced with `matchMedia` API which fires consistently across all viewport change scenarios

  ### 2. Desktop Navigation Overflowing on iPad Pro
  - **Problem**: Horizontal scrollbar appearing on screens at 1024px (iPad Pro portrait) due to 7 nav items being too wide
  - **Root cause**: Mobile/desktop breakpoint was set at 1024px, same width as iPad Pro portrait
  - **Solution**: Increased breakpoint to 1280px (xl) so desktop navigation only appears when there's sufficient space

  ### 3. Footer Floating on Short Pages
  - **Problem**: Footer hovering above bottom of viewport on pages with minimal content (Dashboard, Setup)
  - **Root cause**: No flexbox layout to push footer to bottom
  - **Solution**: Implemented standard sticky footer pattern with `flex flex-col` and `flex-1`

  ## Changes
  - Updated `src/hooks/use-mobile.ts`: Replaced resize events with matchMedia, increased breakpoint to 1280px
  - Updated `src/components/layout/app-shell.tsx`: Added flexbox sticky footer layout
  - Updated `CHANGELOG.md`: Added version 2.12.2 entry
  - Updated `package.json`: Bumped version to 2.12.2

  ## Testing
  - [x] Mobile browser shows hamburger menu correctly
  - [x] Chrome DevTools device dropdown switches navigation properly
  - [x] iPad Pro portrait (1024px) shows mobile navigation
  - [x] Desktop (1280px+) shows horizontal navigation without overflow
  - [x] Footer sticks to bottom on Dashboard and Setup pages
  - [x] Footer flows normally on long pages (Progress, Kanji)
  - [x] Build passes without errors

  ## Preview
  **Before**: Desktop nav overflowing on iPad Pro, footer floating on short pages
  **After**: Clean mobile nav at appropriate breakpoints, footer properly anchored