### PR TITLE
fix: Level milestone

### DIFF
--- a/src/lib/calculations/milestones.ts
+++ b/src/lib/calculations/milestones.ts
@@ -177,7 +177,7 @@ function getLevelMilestones(
         // Otherwise use most recent created_at
         return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
       })[0]
-    const isAchieved = currentLevel > target
+    const isAchieved = currentLevel >= target
     const achievedAt = progression?.passed_at ? new Date(progression.passed_at) : null
 
     return {


### PR DESCRIPTION
   Changed level milestone achievement check from > to >= so that users at a milestone
    level (e.g., level 10) properly see it as achieved instead of requiring them to be
    one level above.