### PR TITLE
fix: Milestone achievement logic and enhanced historical level duration display (v2.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.1] - 2026-01-15
+
+### Fixed
+- **Progress Page: Milestone Achievement Logic**: Fixed level milestones not showing as achieved at exact level
+  - Level 20 milestone now shows as achieved when user reaches level 20 (not level 21)
+  - Changed comparison from `currentLevel > target` to `currentLevel >= target` for consistent behavior
+  - Matches existing burn and guru milestone logic
+
+### Changed
+- **Dashboard Level Progress: Historical Duration Display**: Enhanced time precision for completed levels
+  - **Current level**: Continues to show rounded-up day count (e.g., "Day 10" when 9 days 3 hours in)
+  - **Historical levels (top right)**: Now shows precise duration with hours (e.g., "9d 4h" instead of "Day 10")
+  - **Historical levels (bottom text)**: Shows verbose format (e.g., "Passed Dec 25, 2025 · 9 days 4 hours" instead of "10 days")
+  - Hours are omitted when duration is exactly to the day
+- **Progress Page: Level Timeline Duration Display**: All visualization modes now show precise duration with hours
+  - **Bar Chart**: Hover tooltips display "9d 4h" format instead of "9d"
+  - **Cards View**: Card labels show "9d 4h" format
+  - **Compact List View**: Badge labels show "9d 4h" format
+  - Provides accurate historical completion times across all views
+
+### Technical
+- Updated `src/lib/calculations/milestones.ts`:
+  - Modified `getLevelMilestones()` to use `>=` instead of `>` for level achievement check (line 180)
+- Updated `src/lib/calculations/level-progress.ts`:
+  - Added `durationCompact` and `durationVerbose` fields to `LevelProgressData` interface
+  - Created `formatDurationCompact()` helper function for "9d 4h" format
+  - Created `formatDurationVerbose()` helper function for "9 days 4 hours" format
+  - Enhanced `calculateLevelProgress()` to compute precise durations for historical levels
+  - Exported formatting functions for reuse in other components
+- Updated `src/components/dashboard/level-progress.tsx`:
+  - Modified top-right display to use `durationCompact` for historical levels
+  - Updated bottom text to use `durationVerbose` for historical levels
+- Updated `src/components/progress/level-timeline.tsx`:
+  - Added `durationFormatted` field to `LevelData` interface
+  - Enhanced level progression calculation to track milliseconds for hour precision
+  - Updated all three view modes (bar chart, cards, compact list) to display formatted durations
+
 ## [2.13.0] - 2026-01-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive analytics platform for WaniKani learners. Track your progress, identify problem areas, and optimize your kanji and vocabulary study with detailed insights—all processed locally in your browser.
 
-**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.13.0
+**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.13.1
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.13.0",
+  "version": "2.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/dashboard/level-progress.tsx
+++ b/src/components/dashboard/level-progress.tsx
@@ -107,7 +107,7 @@ export function LevelProgress() {
           </button>
         </div>
         <span className="text-sm text-ink-400 dark:text-paper-300 font-medium">
-          Day {progress.daysOnLevel}
+          {progress.durationCompact || `Day ${progress.daysOnLevel}`}
         </span>
       </div>
 
@@ -147,7 +147,7 @@ export function LevelProgress() {
           ) : progress.passedAt && selectedLevelProgression?.passed_at ? (
             <p className="text-sm text-ink-400 dark:text-paper-300">
               Passed {format(new Date(progress.passedAt), 'MMM d, yyyy')}
-              {progress.daysOnLevel > 0 && <span> · {progress.daysOnLevel} days</span>}
+              {progress.durationVerbose && <span> · {progress.durationVerbose}</span>}
             </p>
           ) : selectedLevelProgression?.unlocked_at ? (
             <p className="text-sm text-ink-400 dark:text-paper-300">In progress</p>

--- a/src/lib/calculations/milestones.ts
+++ b/src/lib/calculations/milestones.ts
@@ -177,7 +177,7 @@ function getLevelMilestones(
         // Otherwise use most recent created_at
         return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
       })[0]
-    const isAchieved = currentLevel > target
+    const isAchieved = currentLevel >= target
     const achievedAt = progression?.passed_at ? new Date(progression.passed_at) : null
 
     return {


### PR DESCRIPTION
## Summary
  Polish improvements to milestone tracking and historical level duration displays, providing more accurate and precise information to users.

  ## Changes

  ### Fixed
  - **Milestone Achievement Logic** (Progress Page)
    - Level milestones now show as achieved when reaching the exact level (e.g., level 20 achieved at level 20, not 21)
    - Changed comparison from `currentLevel > target` to `currentLevel >= target`
    - Aligns with existing burn and guru milestone behavior

  ### Enhanced
  - **Historical Level Duration Display** (Dashboard & Progress Pages)
    - **Current level**: Continues showing rounded-up day count (e.g., "Day 10")
    - **Historical levels**: Now display precise duration with hours
      - Top right of dashboard card: Compact format "9d 4h"
      - Bottom completion text: Verbose format "Passed Dec 25, 2025 · 9 days 4 hours"
      - All level timeline views (bar chart, cards, compact list): Show hour precision
    - Hours automatically omitted when duration is exactly to the day

  ## Technical Details

  ### Files Modified
  - `src/lib/calculations/milestones.ts` - Fixed level milestone achievement logic
  - `src/lib/calculations/level-progress.ts` - Added duration formatting utilities
  - `src/components/dashboard/level-progress.tsx` - Updated duration display
  - `src/components/progress/level-timeline.tsx` - Enhanced all visualization modes
  - `package.json` - Version bump to 2.13.1
  - `README.md` - Version update
  - `CHANGELOG.md` - New release entry

  ### New Functions
  - `formatDurationCompact()` - Returns "9d 4h" format
  - `formatDurationVerbose()` - Returns "9 days 4 hours" format