### PR TITLE
feat: Progress page UX polish and auto-detect breaks toggle (v2.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.0] - 2026-01-17
+
+### Added
+- **Progress Page: Auto-Detect Breaks Toggle**: New user-controllable setting for outlier exclusion behavior
+  - New "Auto-detect breaks" toggle in Settings → Progress section
+  - When enabled (default): Automatically excludes outlier levels using MAD-based statistical analysis
+  - When disabled: All levels included in averages; long levels still colored based on pace but not excluded
+  - Visual indicators adapt based on setting (e.g., break legend only shown when auto-exclusion is active)
+  - Consistent story across Progress page and Journey to Level 60 component
+
+### Changed
+- **Progress Page: UX Polish & Clarity Improvements**
+  - Removed confusing small grey box next to "x levels auto-detected as breaks" text
+  - Replaced "Trimmed mean" technical jargon with user-friendly "Based on X active levels" text
+  - Updated Journey to Level 60 expected scenario description to reflect setting state:
+    - Auto-exclude ON: "Based on your active pace (excludes breaks)"
+    - Auto-exclude OFF: "Based on your average pace (all levels)"
+  - Level history average now shows clearer wording:
+    - Auto-exclude ON: "Average: 24 days (16 active levels)"
+    - Auto-exclude OFF: "Average: 24 days (all 16 levels)"
+  - Break legend item conditionally shown only when breaks are auto-detected
+  - Integrated break detection info into stats section (removed isolated container)
+- **Settings Page: Reorganized Sections** to match navbar order for improved discoverability
+  - New order: Account → Data Sync → Data Export → Progress → Accuracy → Forecast → Leeches → Kanji → Readiness → Danger Zone
+  - Consolidated Progress settings: auto-detect breaks toggle + level history visualization mode
+
+### Technical
+- Updated `src/stores/settings-store.ts`:
+  - Added `autoExcludeBreaks` boolean setting (default: true)
+  - Added `setAutoExcludeBreaks()` action
+- Updated `src/lib/calculations/activity-analysis.ts`:
+  - Modified `analyzeUnifiedLevelData()` signature to accept `autoExcludeBreaks` parameter
+  - Outlier detection now conditional based on setting
+- Updated `src/lib/calculations/forecasting.ts`:
+  - Modified `projectLevel60Date()` signature to accept `autoExcludeBreaks` parameter
+  - Passes setting through to `analyzeUnifiedLevelData()` call
+- Updated `src/components/progress/level-timeline.tsx`:
+  - Retrieves and passes `autoExcludeBreaks` setting to analysis function
+  - Conditional rendering of break legend based on setting and excluded level count
+  - Updated average text to adapt based on setting
+  - Integrated break detection info into stats section (removed separate container)
+- Updated `src/components/progress/level-60-projection.tsx`:
+  - Retrieves and passes `autoExcludeBreaks` setting to projection function
+  - Dynamic "Based on" text adapts to setting state
+  - Dynamic expected scenario description reflects exclusion behavior
+- Updated `src/pages/settings.tsx`:
+  - Created new "Progress" settings section with auto-detect breaks toggle
+  - Consolidated level history visualization mode under Progress section
+  - Reordered all settings sections to match navbar order
+
 ## [2.14.0] - 2026-01-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive analytics platform for WaniKani learners. Track your progress, identify problem areas, and optimize your kanji and vocabulary study with detailed insights—all processed locally in your browser.
 
-**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.14.0
+**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.15.0
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.14.0",
+  "version": "2.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/progress/level-timeline.tsx
+++ b/src/components/progress/level-timeline.tsx
@@ -184,6 +184,7 @@ export function LevelTimeline() {
   const { data: levelProgressions, isLoading: progressionsLoading } = useLevelProgressions()
   const isSyncing = useSyncStore((state) => state.isSyncing)
   const levelHistoryMode = useSettingsStore((state) => state.levelHistoryMode)
+  const autoExcludeBreaks = useSettingsStore((state) => state.autoExcludeBreaks)
 
   const isLoading = userLoading || progressionsLoading || isSyncing
 
@@ -198,7 +199,7 @@ export function LevelTimeline() {
 
   if (levelProgressions && user) {
     // Use unified MAD analysis
-    const analysis = analyzeUnifiedLevelData(levelProgressions)
+    const analysis = analyzeUnifiedLevelData(levelProgressions, autoExcludeBreaks)
     avgDays = analysis.average
     outlierThreshold = analysis.outlierThreshold
     excludedCount = analysis.excludedLevels.length
@@ -322,7 +323,7 @@ export function LevelTimeline() {
           <span className="text-ink-100 dark:text-paper-100 font-semibold">{Math.round(avgDays)} days</span>
           {includedCount > 0 && (
             <span className="text-xs text-ink-400 dark:text-paper-300 ml-1">
-              (of {includedCount} levels)
+              ({autoExcludeBreaks && excludedCount > 0 ? `${includedCount} active levels` : `all ${includedCount} levels`})
             </span>
           )}
         </div>
@@ -334,20 +335,15 @@ export function LevelTimeline() {
           <span className="text-ink-400 dark:text-paper-300">Slowest:</span>{' '}
           <span className="text-vermillion-500 dark:text-vermillion-400 font-semibold">{slowestDays} days</span>
         </div>
-      </div>
-
-      {/* Automatic break detection info - only show if there are excluded levels */}
-      {excludedCount > 0 && (
-        <div className="mb-8 p-3 bg-paper-300/50 dark:bg-ink-300/50 rounded-lg">
-          <div className="flex items-center gap-2 text-sm text-ink-100 dark:text-paper-100">
-            <div className="w-3 h-3 bg-ink-400 dark:bg-paper-400 rounded-sm flex-shrink-0" />
-            <span className="font-medium">
+        {autoExcludeBreaks && excludedCount > 0 && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-ink-400 dark:text-paper-300">
               {excludedCount} {excludedCount === 1 ? 'level' : 'levels'} auto-detected as {excludedCount === 1 ? 'a break' : 'breaks'}
             </span>
             <InfoTooltip content={`Levels longer than ${Math.round(outlierThreshold)} days are automatically detected as breaks using statistical analysis (MAD - Median Absolute Deviation). These are shown in gray and excluded from your average to give you a more accurate picture of your active learning pace.`} />
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Visualization - conditional based on mode */}
       {(() => {
@@ -387,10 +383,12 @@ export function LevelTimeline() {
           <div className="w-4 h-2 bg-vermillion-500 dark:bg-vermillion-400 rounded-full" />
           <span className="text-ink-400 dark:text-paper-300">Very Slow - Significantly slower</span>
         </div>
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-2 bg-ink-400 dark:bg-paper-400 rounded-full" />
-          <span className="text-ink-400 dark:text-paper-300">Break - Auto-excluded from average</span>
-        </div>
+        {autoExcludeBreaks && excludedCount > 0 && (
+          <div className="flex items-center gap-2">
+            <div className="w-4 h-2 bg-ink-400 dark:bg-paper-400 rounded-full" />
+            <span className="text-ink-400 dark:text-paper-300">Break - Auto-excluded from average</span>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/lib/calculations/activity-analysis.ts
+++ b/src/lib/calculations/activity-analysis.ts
@@ -129,10 +129,13 @@ function determinePace(
 
 /**
  * New unified analysis function using MAD for outlier detection
- * No settings needed - fully automatic!
+ *
+ * @param progressions - Array of level progressions
+ * @param autoExcludeBreaks - Whether to automatically exclude outlier levels as breaks (default: true)
  */
 export function analyzeUnifiedLevelData(
-  progressions: LevelProgression[]
+  progressions: LevelProgression[],
+  autoExcludeBreaks: boolean = true
 ): UnifiedLevelAnalysis {
   const durations = calculateLevelDurations(progressions)
 
@@ -162,7 +165,7 @@ export function analyzeUnifiedLevelData(
   // Using 2× multiplier for tighter outlier detection (more aggressive than 3×)
   // But only if we have 5+ levels (need sufficient data for outlier detection)
   const outlierThreshold = median + 2 * normalizedMad
-  const shouldDetectOutliers = durations.length >= 5
+  const shouldDetectOutliers = autoExcludeBreaks && durations.length >= 5
 
   const includedDurations: Array<{ level: number; days: number; milliseconds: number }> = []
   const excludedDurations: Array<{ level: number; days: number; reason: 'outlier' }> = []

--- a/src/lib/calculations/forecasting.ts
+++ b/src/lib/calculations/forecasting.ts
@@ -132,11 +132,16 @@ export function calculateReviewForecast(assignments: Assignment[]): ReviewForeca
 
 /**
  * Project date to reach level 60 based on historical pace
- * Now using unified MAD analysis - no settings needed!
+ * Now using unified MAD analysis
+ *
+ * @param currentLevel - User's current level
+ * @param levelProgressions - Array of level progressions
+ * @param autoExcludeBreaks - Whether to automatically exclude outlier levels as breaks (default: true)
  */
 export function projectLevel60Date(
   currentLevel: number,
-  levelProgressions: LevelProgression[]
+  levelProgressions: LevelProgression[],
+  autoExcludeBreaks: boolean = true
 ): Level60Projection {
   if (currentLevel >= 60) {
     // Already at max level
@@ -154,7 +159,7 @@ export function projectLevel60Date(
   }
 
   // Use unified MAD analysis
-  const analysis = analyzeUnifiedLevelData(levelProgressions)
+  const analysis = analyzeUnifiedLevelData(levelProgressions, autoExcludeBreaks)
 
   if (analysis.includedLevels.length === 0) {
     // No historical data, use default estimates

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -26,7 +26,9 @@ export function Settings() {
     forecastIncludeVocabulary,
     setForecastIncludeVocabulary,
     showAllLevelsInAccuracy,
-    setShowAllLevelsInAccuracy
+    setShowAllLevelsInAccuracy,
+    autoExcludeBreaks,
+    setAutoExcludeBreaks
   } = useSettingsStore()
   const { confirm, ConfirmDialog } = useConfirm()
 
@@ -173,94 +175,139 @@ export function Settings() {
       {/* Data Export */}
       <DataExportSection />
 
-      {/* Exam Readiness Settings */}
+      {/* Progress Settings */}
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
         <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
-          Exam Readiness
+          Progress
         </h2>
-        <div className="space-y-4">
-          <div>
-            <div className="flex items-center gap-2 mb-3">
-              <label className="text-sm font-medium text-ink-100 dark:text-paper-100">
-                SRS Threshold
-              </label>
-              <InfoTooltip content="Choose what SRS stage counts as 'known' for exam readiness calculations (Jōyō kanji and JLPT approximations). Higher thresholds are stricter - Guru+ (recommended) means kanji must be at Guru stage or higher to count as known." />
-            </div>
-            <select
-              value={jlptThreshold}
-              onChange={(e) => setJlptThreshold(e.target.value as SRSThreshold)}
-              className="w-full px-4 py-2 text-sm bg-paper-100 dark:bg-ink-100 border border-paper-300 dark:border-ink-300 rounded-md text-ink-100 dark:text-paper-100 focus:outline-none focus:ring-2 focus:ring-vermillion-500/20"
-            >
-              {(['apprentice_4', 'guru', 'master', 'enlightened', 'burned'] as SRSThreshold[]).map(
-                (threshold) => (
-                  <option key={threshold} value={threshold}>
-                    {SRS_THRESHOLD_LABELS[threshold]}
-                  </option>
-                )
-              )}
-            </select>
-            <div className="text-xs text-ink-400 dark:text-paper-300 mt-2">
-              {SRS_THRESHOLD_DESCRIPTIONS[jlptThreshold]}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Kanji Grid Settings */}
-      <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
-        <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
-          Kanji Grid
-        </h2>
-        <div className="space-y-4">
+        <div className="space-y-6">
+          {/* Auto-exclude breaks toggle */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <label className="text-sm font-medium text-ink-100 dark:text-paper-100">
-                Show Removed Items
+                Auto-detect breaks
               </label>
-              <InfoTooltip content="Show items that have been removed from the WaniKani curriculum. These are subjects you may have studied before they were removed, but are no longer taught to new students." />
+              <InfoTooltip content="Automatically exclude unusually long levels (statistical outliers) from your average pace calculation. These levels are detected using MAD (Median Absolute Deviation) and shown in gray on the timeline. When disabled, all levels are included in averages." />
             </div>
             <button
-              onClick={() => setShowHiddenItems(!showHiddenItems)}
+              onClick={() => setAutoExcludeBreaks(!autoExcludeBreaks)}
               className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                showHiddenItems
+                autoExcludeBreaks
                   ? 'bg-vermillion-500'
                   : 'bg-paper-300 dark:bg-ink-300'
               }`}
             >
               <span
                 className={`inline-block h-4 w-4 transform rounded-full bg-paper-100 dark:bg-ink-100 transition-transform ${
-                  showHiddenItems ? 'translate-x-6' : 'translate-x-1'
+                  autoExcludeBreaks ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
             </button>
           </div>
+
+          {/* Level History Display Mode */}
+          <div>
+            <div className="text-sm font-medium text-ink-100 dark:text-paper-100 mb-3">
+              Level History Visualization
+            </div>
+            <div className="space-y-3">
+              {/* Bar Chart Option */}
+              <label className="flex items-center gap-3 cursor-pointer group">
+                <input
+                  type="radio"
+                  name="levelHistoryMode"
+                  value="bar-chart"
+                  checked={levelHistoryMode === 'bar-chart'}
+                  onChange={(e) => setLevelHistoryMode(e.target.value as 'bar-chart' | 'cards' | 'compact-list')}
+                  className="w-4 h-4 text-vermillion-500 border-paper-300 dark:border-ink-300 focus:ring-2 focus:ring-vermillion-500/20"
+                />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-ink-100 dark:text-paper-100">
+                      Bar Chart (recommended)
+                    </span>
+                    <InfoTooltip content="Vertical bars showing days per level with capped linear scale. All normal-pace levels are fully visible, while auto-detected breaks (outliers) are capped at your normal range maximum. Provides clear visual comparison of your typical level completion times." />
+                  </div>
+                  <div className="text-xs text-ink-400 dark:text-paper-300 mt-1">
+                    Vertical bars with capped linear scale (outliers capped)
+                  </div>
+                </div>
+              </label>
+
+              {/* Level Cards Option */}
+              <label className="flex items-center gap-3 cursor-pointer group">
+                <input
+                  type="radio"
+                  name="levelHistoryMode"
+                  value="cards"
+                  checked={levelHistoryMode === 'cards'}
+                  onChange={(e) => setLevelHistoryMode(e.target.value as 'bar-chart' | 'cards' | 'compact-list')}
+                  className="w-4 h-4 text-vermillion-500 border-paper-300 dark:border-ink-300 focus:ring-2 focus:ring-vermillion-500/20"
+                />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-ink-100 dark:text-paper-100">
+                      Level Cards
+                    </span>
+                    <InfoTooltip content="Grid of cards showing level number, days, and pace color. Easy to scan individual level stats at a glance." />
+                  </div>
+                  <div className="text-xs text-ink-400 dark:text-paper-300 mt-1">
+                    Grid of cards showing level, days, and pace color
+                  </div>
+                </div>
+              </label>
+
+              {/* Compact List Option */}
+              <label className="flex items-center gap-3 cursor-pointer group">
+                <input
+                  type="radio"
+                  name="levelHistoryMode"
+                  value="compact-list"
+                  checked={levelHistoryMode === 'compact-list'}
+                  onChange={(e) => setLevelHistoryMode(e.target.value as 'bar-chart' | 'cards' | 'compact-list')}
+                  className="w-4 h-4 text-vermillion-500 border-paper-300 dark:border-ink-300 focus:ring-2 focus:ring-vermillion-500/20"
+                />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-ink-100 dark:text-paper-100">
+                      Compact List
+                    </span>
+                    <InfoTooltip content="Horizontal scrollable colored badges showing all levels compactly. Most space-efficient option." />
+                  </div>
+                  <div className="text-xs text-ink-400 dark:text-paper-300 mt-1">
+                    Horizontal scrollable colored badges
+                  </div>
+                </div>
+              </label>
+            </div>
+          </div>
         </div>
       </div>
 
-      {/* Leeches Settings */}
+      {/* Accuracy Settings */}
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
         <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
-          Leeches
+          Accuracy
         </h2>
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <label className="text-sm font-medium text-ink-100 dark:text-paper-100">
-                Include Burned Items
+                Show all levels in Accuracy by Level
               </label>
-              <InfoTooltip content="Show items that eventually reached burned status in the leeches list. Useful to see items you struggled with historically, even if they're now burned." />
+              <InfoTooltip content="When enabled, shows accuracy data for items that have moved to levels beyond your current level due to curriculum updates. When disabled (default), only shows levels up to your current level to avoid confusion." />
             </div>
             <button
-              onClick={() => setIncludeBurnedLeeches(!includeBurnedLeeches)}
+              onClick={() => setShowAllLevelsInAccuracy(!showAllLevelsInAccuracy)}
               className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                includeBurnedLeeches
+                showAllLevelsInAccuracy
                   ? 'bg-vermillion-500'
                   : 'bg-paper-300 dark:bg-ink-300'
               }`}
             >
               <span
                 className={`inline-block h-4 w-4 transform rounded-full bg-paper-100 dark:bg-ink-100 transition-transform ${
-                  includeBurnedLeeches ? 'translate-x-6' : 'translate-x-1'
+                  showAllLevelsInAccuracy ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
             </button>
@@ -299,30 +346,30 @@ export function Settings() {
         </div>
       </div>
 
-      {/* Accuracy Settings */}
+      {/* Leeches Settings */}
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
         <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
-          Accuracy
+          Leeches
         </h2>
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <label className="text-sm font-medium text-ink-100 dark:text-paper-100">
-                Show all levels in Accuracy by Level
+                Include Burned Items
               </label>
-              <InfoTooltip content="When enabled, shows accuracy data for items that have moved to levels beyond your current level due to curriculum updates. When disabled (default), only shows levels up to your current level to avoid confusion." />
+              <InfoTooltip content="Show items that eventually reached burned status in the leeches list. Useful to see items you struggled with historically, even if they're now burned." />
             </div>
             <button
-              onClick={() => setShowAllLevelsInAccuracy(!showAllLevelsInAccuracy)}
+              onClick={() => setIncludeBurnedLeeches(!includeBurnedLeeches)}
               className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                showAllLevelsInAccuracy
+                includeBurnedLeeches
                   ? 'bg-vermillion-500'
                   : 'bg-paper-300 dark:bg-ink-300'
               }`}
             >
               <span
                 className={`inline-block h-4 w-4 transform rounded-full bg-paper-100 dark:bg-ink-100 transition-transform ${
-                  showAllLevelsInAccuracy ? 'translate-x-6' : 'translate-x-1'
+                  includeBurnedLeeches ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
             </button>
@@ -330,84 +377,66 @@ export function Settings() {
         </div>
       </div>
 
-      {/* Level History Display */}
+      {/* Kanji Grid Settings */}
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
         <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
-          Level History Display
+          Kanji Grid
         </h2>
-        <div>
-          <div className="text-sm font-medium text-ink-100 dark:text-paper-100 mb-3">
-            Visualization Mode
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium text-ink-100 dark:text-paper-100">
+                Show Removed Items
+              </label>
+              <InfoTooltip content="Show items that have been removed from the WaniKani curriculum. These are subjects you may have studied before they were removed, but are no longer taught to new students." />
+            </div>
+            <button
+              onClick={() => setShowHiddenItems(!showHiddenItems)}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                showHiddenItems
+                  ? 'bg-vermillion-500'
+                  : 'bg-paper-300 dark:bg-ink-300'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-paper-100 dark:bg-ink-100 transition-transform ${
+                  showHiddenItems ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
           </div>
-          <div className="space-y-3">
-            {/* Bar Chart Option */}
-            <label className="flex items-center gap-3 cursor-pointer group">
-              <input
-                type="radio"
-                name="levelHistoryMode"
-                value="bar-chart"
-                checked={levelHistoryMode === 'bar-chart'}
-                onChange={(e) => setLevelHistoryMode(e.target.value as 'bar-chart' | 'cards' | 'compact-list')}
-                className="w-4 h-4 text-vermillion-500 border-paper-300 dark:border-ink-300 focus:ring-2 focus:ring-vermillion-500/20"
-              />
-              <div className="flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-ink-100 dark:text-paper-100">
-                    Bar Chart (recommended)
-                  </span>
-                  <InfoTooltip content="Vertical bars showing days per level with capped linear scale. All normal-pace levels are fully visible, while auto-detected breaks (outliers) are capped at your normal range maximum. Provides clear visual comparison of your typical level completion times." />
-                </div>
-                <div className="text-xs text-ink-400 dark:text-paper-300 mt-1">
-                  Vertical bars with capped linear scale (outliers capped)
-                </div>
-              </div>
-            </label>
+        </div>
+      </div>
 
-            {/* Level Cards Option */}
-            <label className="flex items-center gap-3 cursor-pointer group">
-              <input
-                type="radio"
-                name="levelHistoryMode"
-                value="cards"
-                checked={levelHistoryMode === 'cards'}
-                onChange={(e) => setLevelHistoryMode(e.target.value as 'bar-chart' | 'cards' | 'compact-list')}
-                className="w-4 h-4 text-vermillion-500 border-paper-300 dark:border-ink-300 focus:ring-2 focus:ring-vermillion-500/20"
-              />
-              <div className="flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-ink-100 dark:text-paper-100">
-                    Level Cards
-                  </span>
-                  <InfoTooltip content="Grid of cards showing level number, days, and pace color. Easy to scan individual level stats at a glance." />
-                </div>
-                <div className="text-xs text-ink-400 dark:text-paper-300 mt-1">
-                  Grid of cards showing level, days, and pace color
-                </div>
-              </div>
-            </label>
-
-            {/* Compact List Option */}
-            <label className="flex items-center gap-3 cursor-pointer group">
-              <input
-                type="radio"
-                name="levelHistoryMode"
-                value="compact-list"
-                checked={levelHistoryMode === 'compact-list'}
-                onChange={(e) => setLevelHistoryMode(e.target.value as 'bar-chart' | 'cards' | 'compact-list')}
-                className="w-4 h-4 text-vermillion-500 border-paper-300 dark:border-ink-300 focus:ring-2 focus:ring-vermillion-500/20"
-              />
-              <div className="flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-ink-100 dark:text-paper-100">
-                    Compact List
-                  </span>
-                  <InfoTooltip content="Horizontal scrollable colored badges showing all levels compactly. Most space-efficient option." />
-                </div>
-                <div className="text-xs text-ink-400 dark:text-paper-300 mt-1">
-                  Horizontal scrollable colored badges
-                </div>
-              </div>
-            </label>
+      {/* Exam Readiness Settings */}
+      <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-sm">
+        <h2 className="text-lg font-display font-semibold text-ink-100 dark:text-paper-100 mb-4">
+          Exam Readiness
+        </h2>
+        <div className="space-y-4">
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <label className="text-sm font-medium text-ink-100 dark:text-paper-100">
+                SRS Threshold
+              </label>
+              <InfoTooltip content="Choose what SRS stage counts as 'known' for exam readiness calculations (Jōyō kanji and JLPT approximations). Higher thresholds are stricter - Guru+ (recommended) means kanji must be at Guru stage or higher to count as known." />
+            </div>
+            <select
+              value={jlptThreshold}
+              onChange={(e) => setJlptThreshold(e.target.value as SRSThreshold)}
+              className="w-full px-4 py-2 text-sm bg-paper-100 dark:bg-ink-100 border border-paper-300 dark:border-ink-300 rounded-md text-ink-100 dark:text-paper-100 focus:outline-none focus:ring-2 focus:ring-vermillion-500/20"
+            >
+              {(['apprentice_4', 'guru', 'master', 'enlightened', 'burned'] as SRSThreshold[]).map(
+                (threshold) => (
+                  <option key={threshold} value={threshold}>
+                    {SRS_THRESHOLD_LABELS[threshold]}
+                  </option>
+                )
+              )}
+            </select>
+            <div className="text-xs text-ink-400 dark:text-paper-300 mt-2">
+              {SRS_THRESHOLD_DESCRIPTIONS[jlptThreshold]}
+            </div>
           </div>
         </div>
       </div>

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -15,6 +15,7 @@ interface SettingsState {
   includeBurnedLeeches: boolean // default: false - exclude burned items from leeches
   forecastIncludeVocabulary: boolean // default: true - include vocabulary in level progression forecast
   showAllLevelsInAccuracy: boolean // default: false - show levels beyond user's current level in accuracy by level
+  autoExcludeBreaks: boolean // default: true - automatically exclude outlier levels as breaks from averages
 
   // Actions
   setTheme: (theme: 'light' | 'dark') => void
@@ -27,6 +28,7 @@ interface SettingsState {
   setIncludeBurnedLeeches: (value: boolean) => void
   setForecastIncludeVocabulary: (value: boolean) => void
   setShowAllLevelsInAccuracy: (value: boolean) => void
+  setAutoExcludeBreaks: (value: boolean) => void
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -43,6 +45,7 @@ export const useSettingsStore = create<SettingsState>()(
       includeBurnedLeeches: false, // default to excluding burned items from leeches
       forecastIncludeVocabulary: true, // default to including vocabulary
       showAllLevelsInAccuracy: false, // default to hiding levels beyond current level
+      autoExcludeBreaks: true, // default to auto-excluding outlier levels as breaks
 
       // Actions
       setTheme: (theme: 'light' | 'dark') => {
@@ -93,6 +96,10 @@ export const useSettingsStore = create<SettingsState>()(
 
       setShowAllLevelsInAccuracy: (value: boolean) => {
         set({ showAllLevelsInAccuracy: value })
+      },
+
+      setAutoExcludeBreaks: (value: boolean) => {
+        set({ autoExcludeBreaks: value })
       },
     }),
     {


### PR DESCRIPTION
## Summary
  Polish pass on the Progress page with improved UX clarity and a new user-controllable toggle for break detection behavior.

  ## Changes

  ### New Feature: Auto-Detect Breaks Toggle
  - Added new "Auto-detect breaks" setting in Settings → Progress
  - Default ON: Excludes outlier levels using MAD-based statistical analysis (current behavior)
  - When OFF: Includes all levels in averages; long levels still colored by pace but not excluded
  - Consistent behavior across Progress page timeline and Journey to Level 60 component

  ### UX Polish
  - **Removed confusion**: Deleted small grey box next to "x levels auto-detected as breaks" text
  - **Clearer language**: Replaced "Trimmed mean" jargon with user-friendly "Based on X active levels" text
  - **Dynamic wording**: All text adapts based on auto-exclude setting state:
    - Journey to Level 60: "Based on your active pace (excludes breaks)" vs "Based on your average pace (all levels)"
    - Level history average: "(16 active levels)" vs "(all 16 levels)"
  - **Conditional UI**: Break legend only shown when breaks are actually auto-detected
  - **Better integration**: Moved break detection info into stats section (removed isolated container)

  ### Settings Reorganization
  - Reordered settings sections to match navbar order for improved discoverability
  - New order: Account → Data Sync → Data Export → **Progress** → Accuracy → Forecast → Leeches → Kanji → Readiness → Danger Zone
  - Consolidated Progress settings: auto-detect breaks toggle + level history visualization mode

  ## Technical Details
  - New setting: `autoExcludeBreaks` in settings store (default: true)
  - Updated analysis functions to accept and respect the setting
  - Conditional rendering throughout Progress components based on setting state

  ## Testing
  - [x] Toggle setting on/off and verify all text updates correctly
  - [x] Verify break legend appears/disappears appropriately
  - [x] Confirm calculations respect the setting
  - [x] Check Journey to Level 60 projection adapts correctly