### PR TITLE
housekeeping: fix reset level count in projection, parallel sync with better error handling, eliminate redundant indexeddb reads on navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.19.2] - 2026-03-03
+
+### Fixed
+- **Progress: Level 60 Projection — "Based on X completed levels" Count Incorrect After Reset**: The completed levels count shown in the projection footer now filters to post-reset progressions only, consistent with how the rest of the projection is calculated
+  - Previously the count included all historical progressions, so a user who reset from level 30 to level 1 would see a completed level count that included their pre-reset history
+  - Non-reset users are unaffected
+
+### Technical
+- **Sync: Parallel data sync with improved error handling**: Assignments, review statistics, and level progressions now sync concurrently after subjects complete, rather than sequentially. Wall-clock sync time is unchanged (WaniKani's 60 req/min rate limit is the bottleneck regardless), but partial failures are now handled gracefully — if one or two syncs fail, the others still complete and the app continues with the data it has, rather than aborting the entire sync
+- **Queries: Eliminated redundant IndexedDB reads on page navigation**: The four IndexedDB-backed query hooks (`useSubjects`, `useAssignments`, `useReviewStatistics`, `useLevelProgressions`) now use `staleTime: 5min`, `gcTime: 30min`, and `refetchOnMount: false`. Previously `staleTime: 0` + `refetchOnMount: 'always'` caused a full IndexedDB read on every page mount. Post-sync query invalidation already handles freshness after a sync, making the per-navigation reads redundant
+
 ## [2.19.1] - 2026-03-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive analytics platform for WaniKani learners. Track your progress, identify problem areas, and optimize your kanji and vocabulary study with detailed insights—all processed locally in your browser.
 
-**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.19.1
+**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.19.2
 
 ---
 
@@ -25,7 +25,7 @@ Long-term analysis and projections:
 
 ### Workload Forecasting
 Plan your lesson pace and predict future review workload:
-- **Lesson Pace Configuration**: Set lessons per day (0-999) and forecast period (7-180 days) with presets or custom values
+- **Lesson Pace Configuration**: Set lessons per day (0-100) and forecast period (7-180 days) with presets or custom values
 - **Workload Metrics**: Track peak day, average daily reviews, stabilization point, and total reviews over the forecast period
 - **Level Progression Forecast**: Projects what level you'll reach based on your lesson pace, accounting for your current progress
 - **Interactive Charts**: Daily or weekly view of projected workload, split between existing items and new lessons

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.19.1",
+  "version": "2.19.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/progress/level-60-projection.tsx
+++ b/src/components/progress/level-60-projection.tsx
@@ -4,6 +4,7 @@ import { Rocket, TrendingUp, Turtle } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 import { useUser, useLevelProgressions, useResets } from '@/lib/api/queries'
 import { projectLevel60Date } from '@/lib/calculations/forecasting'
+import { filterPostResetProgressions } from '@/lib/calculations/progression-filter'
 import { formatDurationCompact } from '@/lib/calculations/level-progress'
 import { useSyncStore } from '@/stores/sync-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -110,9 +111,9 @@ export function Level60Projection() {
       })()
     : []
 
-  // Calculate completed levels count
+  // Calculate completed levels count (post-reset only, so it's consistent with the projection)
   const completedLevels = levelProgressions
-    ? levelProgressions.filter(p => p.passed_at && p.unlocked_at).length
+    ? filterPostResetProgressions(levelProgressions, resets).filter(p => p.passed_at && p.unlocked_at).length
     : 0
 
   // Build scenarios

--- a/src/lib/api/queries.ts
+++ b/src/lib/api/queries.ts
@@ -80,7 +80,8 @@ export function useSummary() {
 
 /**
  * Subjects - loaded from IndexedDB cache
- * Always checks for updates on mount to ensure fresh data
+ * Kept fresh for 5 min; post-sync invalidation (removeQueries + refetchQueries in use-sync.ts)
+ * handles freshness after a sync, so redundant per-navigation reads are unnecessary.
  */
 export function useSubjects() {
   const token = useUserStore((state) => state.token)
@@ -90,16 +91,17 @@ export function useSubjects() {
     queryKey: queryKeys.subjects,
     queryFn: getCachedSubjects,
     enabled: !!token && !isSyncing,
-    staleTime: 0, // Always check for fresh data
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnMount: 'always',
+    staleTime: 5 * 60 * 1000, // 5 min — data only changes on sync
+    gcTime: 30 * 60 * 1000, // 30 min
+    refetchOnMount: false, // post-sync invalidation handles freshness
     retry: 1,
   })
 }
 
 /**
  * Assignments - loaded from IndexedDB cache
- * Always checks for updates on mount to ensure fresh data
+ * Kept fresh for 5 min; post-sync invalidation (removeQueries + refetchQueries in use-sync.ts)
+ * handles freshness after a sync, so redundant per-navigation reads are unnecessary.
  */
 export function useAssignments() {
   const token = useUserStore((state) => state.token)
@@ -109,16 +111,17 @@ export function useAssignments() {
     queryKey: queryKeys.assignments,
     queryFn: getCachedAssignments,
     enabled: !!token && !isSyncing,
-    staleTime: 0, // Always check for fresh data
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnMount: 'always',
+    staleTime: 5 * 60 * 1000, // 5 min — data only changes on sync
+    gcTime: 30 * 60 * 1000, // 30 min
+    refetchOnMount: false, // post-sync invalidation handles freshness
     retry: 1,
   })
 }
 
 /**
  * Review Statistics - loaded from IndexedDB cache
- * Always checks for updates on mount to ensure fresh data
+ * Kept fresh for 5 min; post-sync invalidation (removeQueries + refetchQueries in use-sync.ts)
+ * handles freshness after a sync, so redundant per-navigation reads are unnecessary.
  */
 export function useReviewStatistics() {
   const token = useUserStore((state) => state.token)
@@ -128,16 +131,17 @@ export function useReviewStatistics() {
     queryKey: queryKeys.reviewStatistics,
     queryFn: getCachedReviewStatistics,
     enabled: !!token && !isSyncing,
-    staleTime: 0, // Always check for fresh data
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnMount: 'always',
+    staleTime: 5 * 60 * 1000, // 5 min — data only changes on sync
+    gcTime: 30 * 60 * 1000, // 30 min
+    refetchOnMount: false, // post-sync invalidation handles freshness
     retry: 1,
   })
 }
 
 /**
  * Level Progressions - loaded from IndexedDB cache
- * Always checks for updates on mount to ensure fresh data
+ * Kept fresh for 5 min; post-sync invalidation (removeQueries + refetchQueries in use-sync.ts)
+ * handles freshness after a sync, so redundant per-navigation reads are unnecessary.
  */
 export function useLevelProgressions() {
   const token = useUserStore((state) => state.token)
@@ -147,9 +151,9 @@ export function useLevelProgressions() {
     queryKey: queryKeys.levelProgressions,
     queryFn: getCachedLevelProgressions,
     enabled: !!token && !isSyncing,
-    staleTime: 0, // Always check for fresh data
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnMount: 'always',
+    staleTime: 5 * 60 * 1000, // 5 min — data only changes on sync
+    gcTime: 30 * 60 * 1000, // 30 min
+    refetchOnMount: false, // post-sync invalidation handles freshness
     retry: 1,
   })
 }

--- a/src/lib/sync/sync-manager.ts
+++ b/src/lib/sync/sync-manager.ts
@@ -52,26 +52,45 @@ export async function performSync(
     result.subjects = subjectsResult.updated
     result.isFullSync = subjectsResult.isFullSync
 
-    // Sync assignments
-    onProgress?.({ phase: 'assignments', message: 'Syncing assignments...', isFullSync: result.isFullSync })
-    const assignmentsResult = await syncAssignments(token, (msg) =>
-      onProgress?.({ phase: 'assignments', message: msg, isFullSync: result.isFullSync })
-    )
-    result.assignments = assignmentsResult.updated
+    // Sync assignments, review stats, and level progressions in parallel —
+    // they're all independent of each other; only subjects needed to go first.
+    onProgress?.({ phase: 'assignments', message: 'Syncing remaining data...', isFullSync: result.isFullSync })
 
-    // Sync review statistics
-    onProgress?.({ phase: 'reviewStats', message: 'Syncing review statistics...', isFullSync: result.isFullSync })
-    const statsResult = await syncReviewStatistics(token, (msg) =>
-      onProgress?.({ phase: 'reviewStats', message: msg, isFullSync: result.isFullSync })
-    )
-    result.reviewStatistics = statsResult.updated
+    let completedCount = 0
+    const phases = ['reviewStats', 'levelProgressions'] as const
+    const advanceProgress = () => {
+      const phase = phases[completedCount++]
+      if (phase) onProgress?.({ phase, message: 'Syncing remaining data...', isFullSync: result.isFullSync })
+    }
 
-    // Sync level progressions
-    onProgress?.({ phase: 'levelProgressions', message: 'Syncing level progressions...', isFullSync: result.isFullSync })
-    const progressionsResult = await syncLevelProgressions(token, (msg) =>
-      onProgress?.({ phase: 'levelProgressions', message: msg, isFullSync: result.isFullSync })
-    )
-    result.levelProgressions = progressionsResult.updated
+    const [assignmentsOutcome, statsOutcome, progressionsOutcome] = await Promise.allSettled([
+      syncAssignments(token).then(r => { advanceProgress(); return r }),
+      syncReviewStatistics(token).then(r => { advanceProgress(); return r }),
+      syncLevelProgressions(token).then(r => { advanceProgress(); return r }),
+    ])
+
+    const errors: string[] = []
+    if (assignmentsOutcome.status === 'fulfilled') {
+      result.assignments = assignmentsOutcome.value.updated
+    } else {
+      errors.push(`assignments: ${assignmentsOutcome.reason instanceof Error ? assignmentsOutcome.reason.message : String(assignmentsOutcome.reason)}`)
+    }
+    if (statsOutcome.status === 'fulfilled') {
+      result.reviewStatistics = statsOutcome.value.updated
+    } else {
+      errors.push(`reviewStats: ${statsOutcome.reason instanceof Error ? statsOutcome.reason.message : String(statsOutcome.reason)}`)
+    }
+    if (progressionsOutcome.status === 'fulfilled') {
+      result.levelProgressions = progressionsOutcome.value.updated
+    } else {
+      errors.push(`levelProgressions: ${progressionsOutcome.reason instanceof Error ? progressionsOutcome.reason.message : String(progressionsOutcome.reason)}`)
+    }
+
+    if (errors.length === 3) {
+      throw new Error(`All parallel syncs failed: ${errors.join('; ')}`)
+    } else if (errors.length > 0) {
+      console.warn('[SYNC] Some parallel syncs failed (partial sync):', errors)
+    }
 
     // Update last full sync time
     await updateSyncMetadata({


### PR DESCRIPTION
Two community PRs were submitted by @manuelgr0.
Each contained at least one genuinely good idea. Rather than merge either directly, I've cherry-picked the valid ideas and implemented them properly.

## What was taken from #39 — [Fix: Count only post-reset levels in Journey to Level 60](https://github.com/tyler-cartwright/wanikani-stats-tracker/pull/39)

**The idea**: The "Based on X completed levels" count in the Level 60 Projection footer was including pre-reset progressions, making it inconsistent with the rest of the projection (which already used `filterPostResetProgressions`).

**Taken**: The fix itself — wrapping `levelProgressions` with `filterPostResetProgressions` before counting. The implementation in the PR was essentially correct; I kept the same approach and added a comment explaining the consistency rationale.

## What was taken from #40 — [Performance optimizations](https://github.com/tyler-cartwright/wanikani-stats-tracker/pull/40)

**Taken: Parallel sync orchestration**. Assignments, review statistics, and level progressions now start concurrently after subjects completes, using `Promise.allSettled` with proper partial-failure handling. A word of caution on the performance numbers quoted in the PR — the claimed 50% reduction in initial sync time doesn't hold up: WaniKani's API is rate-limited to 60 req/min and our client already saturates that ceiling, so the request throughput is identical whether we orchestrate sequentially or in parallel. The real benefit is improved error resilience — previously a single failure would abort the entire sync; now partial failures warn and continue.

**Taken: IndexedDB query cache tuning** (`staleTime`, `gcTime`, `refetchOnMount`). The observation was correct — `staleTime: 0` + `refetchOnMount: 'always'` caused a redundant IndexedDB read on every page navigation. Post-sync invalidation already handles freshness, so these reads were pure overhead. The settings from the PR (`staleTime: 5min`, `gcTime: 30min`, `refetchOnMount: false`) are sound and applied to the four IndexedDB-backed hooks only.

**Not taken: Token bucket rate limiter**. The PR replaced the simple interval-based limiter with a token bucket allowing bursts of 5 requests. While a token bucket is a legitimate pattern, swapping out the rate limiter is a meaningful behavioural change to a core infrastructure component and warrants its own focused PR with explicit verification that  burst behaviour stays within WaniKani's actual limits. It was also bundled into a large multi-concern PR, making it hard to evaluate in isolation.

**Not taken: Calculation memoization hooks** (`src/lib/calculation-queries.ts`). The PR claimed calculation times of "3-5 seconds" reduced to "<100ms" — numbers that don't reflect reality for this app; heavy calculations here run in tens of milliseconds at most. The memoization layer added a new abstraction (`useLeechesQuery`, `useForecastingQuery`, etc.) wrapping existing hooks with 5-minute cache TTLs, but the calculations these run are already fast and the components that use them are already gated behind data-loading states. The complexity cost outweighs the benefit.

**Not taken: Changes to global `QueryClient` defaults in `App.tsx`**. The PR increased default `staleTime` and `gcTime` globally, which would have affected the API-backed hooks (`useUser`, `useSummary`, `useResets`) that intentionally stay fresh. Targeted changes to only the IndexedDB hooks are safer and were applied instead.