### PR TITLE
fix: weighted accuracy calculation for accuracy-by-level chart (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.19.3] - 2026-04-10
+
+### Fixed
+- **Accuracy: Accuracy by Level — Inflated Accuracy Values**: Per-level accuracy bars now use the correct weighted calculation (`total correct / total answers`) instead of an unweighted average of per-item `percentage_correct` values
+  - Previously, a lightly-reviewed item contributed equally to its level's accuracy as one with hundreds of reviews, inflating the displayed values above overall accuracy
+  - Now consistent with how overall, reading, and meaning accuracy are all calculated elsewhere in the app
+  - Also fixes two secondary issues: hidden items were previously included in the chart (they are now excluded, matching the rest of the accuracy page), and kana_vocabulary/radical reading fields were not handled correctly in the old local calculation
+
+### Technical
+- Removed duplicate `calculateAccuracyByLevel()` from `src/components/accuracy/time-heatmap.tsx`; the component now calls the existing `calculateAccuracyMetrics()` from `src/lib/calculations/accuracy.ts`, matching the pattern used by `AccuracyBreakdown` on the same page
+- `AccuracyMetrics.byLevel` enriched from `Map<number, number>` to `Map<number, { accuracy: number; itemCount: number }>` to carry item count alongside accuracy (used for bar tooltips)
+
 ## [2.19.2] - 2026-03-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive analytics platform for WaniKani learners. Track your progress, identify problem areas, and optimize your kanji and vocabulary study with detailed insights—all processed locally in your browser.
 
-**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.19.2
+**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.19.3
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wanitrack",
-  "version": "2.5.2",
+  "version": "2.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wanitrack",
-      "version": "2.5.2",
+      "version": "2.19.2",
       "dependencies": {
         "@tanstack/react-query": "^5.90.11",
         "clsx": "^2.1.1",
@@ -81,7 +81,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2970,7 +2969,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3040,7 +3038,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3310,7 +3307,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -5864,7 +5860,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5940,7 +5935,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5953,7 +5947,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6872,7 +6865,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -7178,7 +7170,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7585,7 +7576,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.19.2",
+  "version": "2.19.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/accuracy/time-heatmap.tsx
+++ b/src/components/accuracy/time-heatmap.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { cn } from '@/lib/utils/cn'
 import { Lightbulb, TrendingDown, TrendingUp } from 'lucide-react'
 import { useReviewStatistics, useSubjects, useUser } from '@/lib/api/queries'
-import type { ReviewStatistic, Subject } from '@/lib/api/types'
+import { calculateAccuracyMetrics } from '@/lib/calculations/accuracy'
 import { useSyncStore } from '@/stores/sync-store'
 import { useSettingsStore } from '@/stores/settings-store'
 
@@ -23,48 +23,6 @@ const getAccuracyColor = (accuracy: number): string => {
   return 'bg-vermillion-500 dark:bg-vermillion-400'
 }
 
-function calculateAccuracyByLevel(
-  reviewStats: ReviewStatistic[],
-  subjects: (Subject & { id: number })[]
-): LevelData[] {
-  // Create a map of subject_id -> level
-  const subjectLevelMap = new Map<number, number>()
-  subjects.forEach((subject) => {
-    if ('level' in subject) {
-      subjectLevelMap.set(subject.id, subject.level)
-    }
-  })
-
-  // Group review statistics by level
-  const levelMap = new Map<number, { totalAccuracy: number; count: number }>()
-
-  reviewStats.forEach((stat) => {
-    const level = subjectLevelMap.get(stat.subject_id)
-    if (!level) return // Skip if we don't have level info
-
-    if (!levelMap.has(level)) {
-      levelMap.set(level, { totalAccuracy: 0, count: 0 })
-    }
-
-    const data = levelMap.get(level)!
-    data.totalAccuracy += stat.percentage_correct
-    data.count += 1
-  })
-
-  // Convert to array and calculate averages
-  const levelData: LevelData[] = []
-  levelMap.forEach((data, level) => {
-    levelData.push({
-      level,
-      accuracy: parseFloat((data.totalAccuracy / data.count).toFixed(2)),
-      itemCount: data.count,
-    })
-  })
-
-  // Sort by level
-  return levelData.sort((a, b) => a.level - b.level)
-}
-
 export function TimeHeatmap() {
   const { data: reviewStats, isLoading: isLoadingStats } = useReviewStatistics()
   const { data: subjects, isLoading: isLoadingSubjects } = useSubjects()
@@ -72,17 +30,25 @@ export function TimeHeatmap() {
   const isSyncing = useSyncStore((state) => state.isSyncing)
   const showAllLevelsInAccuracy = useSettingsStore((state) => state.showAllLevelsInAccuracy)
 
-  const levelData = useMemo(() => {
-    if (!reviewStats || !subjects) return []
-    const allLevelData = calculateAccuracyByLevel(reviewStats, subjects)
+  const metrics = useMemo(() => {
+    if (!reviewStats || !subjects) return null
+    return calculateAccuracyMetrics(reviewStats, subjects)
+  }, [reviewStats, subjects])
 
-    // Filter by user's current level unless showAllLevelsInAccuracy is enabled
+  const levelData = useMemo(() => {
+    if (!metrics) return []
+    const allLevelData: LevelData[] = []
+    metrics.byLevel.forEach(({ accuracy, itemCount }, level) => {
+      allLevelData.push({ level, accuracy, itemCount })
+    })
+    allLevelData.sort((a, b) => a.level - b.level)
+
     if (!showAllLevelsInAccuracy && user?.level) {
       return allLevelData.filter((item) => item.level <= user.level)
     }
 
     return allLevelData
-  }, [reviewStats, subjects, user, showAllLevelsInAccuracy])
+  }, [metrics, user, showAllLevelsInAccuracy])
 
   const bestLevel = useMemo(() => {
     if (levelData.length === 0) return null

--- a/src/lib/calculations/accuracy.ts
+++ b/src/lib/calculations/accuracy.ts
@@ -16,7 +16,7 @@ export interface AccuracyMetrics {
     kanji: { overall: number; reading: number; meaning: number }
     vocabulary: { overall: number; reading: number; meaning: number }
   }
-  byLevel: Map<number, number>
+  byLevel: Map<number, { accuracy: number; itemCount: number }>
 }
 
 /**
@@ -47,7 +47,7 @@ export function calculateAccuracyMetrics(
   }
 
   // By level
-  const levelStats = new Map<number, { correct: number; incorrect: number }>()
+  const levelStats = new Map<number, { correct: number; incorrect: number; itemCount: number }>()
 
   for (const stat of reviewStats) {
     // Exclude hidden items - they're not in active review rotation
@@ -104,12 +104,13 @@ export function calculateAccuracyMetrics(
     if ('level' in subject && subject.level !== undefined) {
       const level = subject.level
       if (!levelStats.has(level)) {
-        levelStats.set(level, { correct: 0, incorrect: 0 })
+        levelStats.set(level, { correct: 0, incorrect: 0, itemCount: 0 })
       }
       const levelStat = levelStats.get(level)
       if (levelStat) {
         levelStat.correct += statTotalCorrect
         levelStat.incorrect += statTotalIncorrect
+        levelStat.itemCount += 1
       }
     }
   }
@@ -152,11 +153,14 @@ export function calculateAccuracyMetrics(
   }
 
   // By level percentages
-  const byLevel = new Map<number, number>()
+  const byLevel = new Map<number, { accuracy: number; itemCount: number }>()
   levelStats.forEach((stat, level) => {
     const levelTotal = stat.correct + stat.incorrect
     if (levelTotal > 0) {
-      byLevel.set(level, parseFloat(((stat.correct / levelTotal) * 100).toFixed(2)))
+      byLevel.set(level, {
+        accuracy: parseFloat(((stat.correct / levelTotal) * 100).toFixed(2)),
+        itemCount: stat.itemCount,
+      })
     }
   })
 


### PR DESCRIPTION
## Summary

  - Fixes inflated accuracy values in the Accuracy by Level chart, reported in #42
  - Removes the duplicate local `calculateAccuracyByLevel()` from `TimeHeatmap` and replaces it with the existing `calculateAccuracyMetrics()` from `accuracy.ts` — the same function already used by `AccuracyBreakdown` on the same page
  - Also fixes two secondary bugs: hidden items were not filtered in the old calculation, and kana_vocabulary/radical reading fields were not handled correctly

  ## Test plan

  - [x] Accuracy by Level bars now show values consistent with (or lower than) the overall accuracy figures in `AccuracyBreakdown`
  - [x] Hidden items no longer appear in the chart
  - [x] Best/worst level callouts and insight box still render correctly
  - [x] `npm run build` passes clean