### PR TITLE
Scroll to expanded readiness details

### DIFF
--- a/src/pages/readiness.tsx
+++ b/src/pages/readiness.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import { useSubjects, useAssignments } from '@/lib/api/queries'
 import { enrichSubjectsWithSRS } from '@/lib/calculations/kanji-grid'
 import { calculateJLPTReadiness } from '@/lib/calculations/jlpt-readiness'
@@ -14,6 +14,7 @@ export function Readiness() {
   useDocumentTitle('Readiness')
   const { jlptThreshold } = useSettingsStore()
   const [expandedLevel, setExpandedLevel] = useState<JoyoGrade | null>(null)
+  const expandedDetailRef = useRef<HTMLDivElement>(null)
   const isSyncing = useSyncStore((state) => state.isSyncing)
 
   // Fetch data
@@ -43,6 +44,20 @@ export function Readiness() {
   const handleToggle = (grade: JoyoGrade) => {
     setExpandedLevel((current) => (current === grade ? null : grade))
   }
+
+  useEffect(() => {
+    if (!expandedLevel || !expandedDetailRef.current) return
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const frameId = window.requestAnimationFrame(() => {
+      expandedDetailRef.current?.scrollIntoView({
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        block: 'start',
+      })
+    })
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [expandedLevel])
 
   // Loading state - skeleton matching actual content structure
   if (isLoading) {
@@ -170,11 +185,13 @@ export function Readiness() {
 
       {/* Expanded Grade Detail */}
       {expandedLevel && (
-        <JLPTLevelDetail
-          data={readiness.grades.find((g) => g.grade === expandedLevel)!}
-          subjects={enrichedSubjects}
-          threshold={jlptThreshold}
-        />
+        <div ref={expandedDetailRef} className="scroll-mt-24">
+          <JLPTLevelDetail
+            data={readiness.grades.find((g) => g.grade === expandedLevel)!}
+            subjects={enrichedSubjects}
+            threshold={jlptThreshold}
+          />
+        </div>
       )}
 
       {/* Footer Info */}


### PR DESCRIPTION
## Summary

- Scroll the Readiness page to the expanded kanji detail after a grade tile is opened or switched.
- Add top scroll margin so the expanded detail is not hidden under the fixed header.
- Respect the user's reduced-motion preference by disabling smooth scrolling when requested.

## Why

The grade tiles can be visible near the bottom of the viewport, while the expanded kanji detail renders below the tile grid. When a user clicks an expand arrow, the newly revealed content can appear below the fold, making it look like nothing happened or forcing a manual scroll.

## Impact

Users are taken directly to the kanji content they just opened, especially when expanding lower tiles such as Grade 4, Grade 5, Grade 6, or Secondary School.

<img width="1180" height="970" alt="Screenshot 2026-05-12 at 7 19 14 AM" src="https://github.com/user-attachments/assets/5ffe4e98-e627-4f88-9bc5-b206109196b4" />


## Validation

- npm run typecheck
- npm run build
- Manually checked the local app at http://127.0.0.1:5173/readiness with existing readiness data