### PR TITLE
fix: open grade detail in modal rather than inline below grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.20.0] - 2026-05-19
+
+### Changed
+- **Readiness: Grade Detail Opens in Modal**: Clicking a grade tile on the Readiness page now opens the kanji detail in a modal rather than expanding a panel below the card grid
+  - The detail is immediately visible regardless of which tile was clicked -- lower tiles (Grade 4, Grade 5, Grade 6, Secondary School) no longer render content far below the fold
+  - Secondary School (~1,130 kanji) handled naturally via the modal's internal scroll
+  - Active grade card highlighted with a vermillion border while the modal is open
+  - Tile affordance updated from a collapsible chevron to a drill-in arrow to reflect the new interaction model
+
+### Fixed
+- **Modal: Animation Ignores prefers-reduced-motion**: Modal open/close animation now responds to the user's reduced-motion system preference; previously the 300ms fade/scale animation played regardless of the OS accessibility setting
+- **Modal: Close Button Overlaps Content**: `ModalClose` is now flow-positioned rather than absolutely positioned, preventing it from overlapping modal content in cases where the modal panel has no relative ancestor
+
+### Technical
+- Added `src/hooks/use-reduced-motion.ts`: reactive hook subscribing to `(prefers-reduced-motion: reduce)` via `matchMedia` + change listener, following the `use-mobile.ts` pattern; consumed by `Modal` so reduced-motion handling is centralised
+- Extended `Modal` with `xl` size (`max-w-5xl`), optional `labelledBy` prop for `aria-labelledby`, and animation duration/unmount delay derived from `useReducedMotion`
+- `JLPTLevelCard`: prop renamed `isExpanded` to `isSelected`; `ChevronDown` replaced with `ArrowUpRight`
+- `JLPTLevelDetail`: outer card chrome removed; component is now content-only and relies on its container (the Modal) for the card wrapper
+
 ## [2.19.3] - 2026-04-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1463,6 +1463,13 @@ WaniTrack v2.0.0 - Complete WaniKani statistics tracker and analytics platform.
 
 ## Version History Summary
 
+- **2.20.0** (May 19, 2026) - Readiness grade detail opens in modal; useReducedMotion hook; Modal xl size, aria-labelledby, reduced-motion-aware animation
+- **2.19.3** (Apr 10, 2026) - Accuracy by Level weighted calculation fix; hidden items excluded; kana_vocabulary/radical reading handling corrected
+- **2.19.2** (Mar 3, 2026) - Level 60 Projection completed-levels count correct after reset
+- **2.19.1** (Mar 1, 2026) - Level history pre-reset filtering via WaniKani resets API; accurate reset dates and level numbers
+- **2.19.0** (Mar 1, 2026) - Reset History Notice on Progress page; pre-reset progressions excluded from level calculations
+- **2.18.1** (Feb 21, 2026) - Toggle overflow fix on narrow screens; Level Timeline bar chart label crowding; projection outlier precision
+- **2.18.0** (Feb 20, 2026) - Dashboard Level Progress granular "time so far" tag
 - **2.17.0** (Feb 18, 2026) - Accuracy breakdown redesign, 2dp accuracy everywhere, reading count correctness fix, dark mode fix
 - **2.16.0** (Jan 17, 2026) - Forecast page streamlined: removed Peak Day/Stabilization/Breakdown, deterministic seeded RNG
 - **2.15.0** (Jan 17, 2026) - Progress page auto-detect breaks toggle, UX polish, settings reorganization

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive analytics platform for WaniKani learners. Track your progress, identify problem areas, and optimize your kanji and vocabulary study with detailed insights—all processed locally in your browser.
 
-**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.19.3
+**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.20.0
 
 ---
 
@@ -54,7 +54,7 @@ Prepare for JLPT exams:
 - Grade-based readiness assessment (N5-N1)
 - Configurable SRS thresholds (Apprentice, Guru, Master, Enlightened)
 - Track mastery progress for each JLPT level
-- Detailed breakdown by kanji, vocabulary, and overall readiness
+- Detailed kanji breakdown per grade, opened in a focused modal with filter controls (All / Known / Unknown)
 
 ### Accuracy Insights
 Understand your performance patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wanitrack",
-  "version": "2.19.2",
+  "version": "2.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wanitrack",
-      "version": "2.19.2",
+      "version": "2.19.3",
       "dependencies": {
         "@tanstack/react-query": "^5.90.11",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.19.3",
+  "version": "2.20.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/jlpt/jlpt-level-card.tsx
+++ b/src/components/jlpt/jlpt-level-card.tsx
@@ -1,15 +1,15 @@
 import type { JoyoLevelData } from '@/data/jlpt'
-import { ChevronDown } from 'lucide-react'
+import { ArrowUpRight } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 import { ProgressBar } from '@/components/shared/progress-bar'
 
 interface JLPTLevelCardProps {
   data: JoyoLevelData
-  isExpanded: boolean
+  isSelected: boolean
   onToggle: () => void
 }
 
-export function JLPTLevelCard({ data, isExpanded, onToggle }: JLPTLevelCardProps) {
+export function JLPTLevelCard({ data, isSelected, onToggle }: JLPTLevelCardProps) {
   const { label, ageRange, kanji, isComplete } = data
 
   // Color based on percentage (using app's SRS color scheme for consistency)
@@ -22,7 +22,12 @@ export function JLPTLevelCard({ data, isExpanded, onToggle }: JLPTLevelCardProps
   const color = getColor()
 
   return (
-    <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-md hover:shadow-lg transition-all">
+    <div className={cn(
+      'bg-paper-200 dark:bg-ink-200 rounded-lg border p-6 shadow-md hover:shadow-lg transition-all',
+      isSelected
+        ? 'border-vermillion-500 ring-1 ring-vermillion-500/30'
+        : 'border-paper-300 dark:border-ink-300'
+    )}>
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
@@ -41,14 +46,9 @@ export function JLPTLevelCard({ data, isExpanded, onToggle }: JLPTLevelCardProps
         <button
           onClick={onToggle}
           className="p-2 rounded-md hover:bg-paper-300 dark:hover:bg-ink-300 transition-smooth focus-ring"
-          aria-label={isExpanded ? 'Collapse' : 'Expand'}
+          aria-label="View details"
         >
-          <ChevronDown
-            className={cn(
-              'w-5 h-5 text-ink-400 dark:text-paper-300 transition-transform',
-              isExpanded && 'rotate-180'
-            )}
-          />
+          <ArrowUpRight className="w-5 h-5 text-ink-400 dark:text-paper-300" />
         </button>
       </div>
 

--- a/src/components/jlpt/jlpt-level-detail.tsx
+++ b/src/components/jlpt/jlpt-level-detail.tsx
@@ -76,12 +76,12 @@ export function JLPTLevelDetail({ data, subjects, threshold }: JLPTLevelDetailPr
   }, [items, subjectMap])
 
   return (
-    <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6 shadow-md">
+    <div className="p-6">
       {/* Header with filters */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
         {/* Title */}
         <div>
-          <h3 className="text-xl font-bold text-ink-100 dark:text-paper-100">{data.label} Kanji</h3>
+          <h3 id="jlpt-level-detail-title" className="text-xl font-bold text-ink-100 dark:text-paper-100">{data.label} Kanji</h3>
           <p className="text-sm text-ink-400 dark:text-paper-300 mt-1">
             {data.kanji.total} total kanji ({data.kanji.inWanikani} in WaniKani)
           </p>

--- a/src/components/shared/modal.tsx
+++ b/src/components/shared/modal.tsx
@@ -2,18 +2,22 @@ import { ReactNode, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
+import { useReducedMotion } from '@/hooks/use-reduced-motion'
 
 interface ModalProps {
   isOpen: boolean
   onClose: () => void
   children: ReactNode
-  size?: 'sm' | 'md' | 'lg'
+  size?: 'sm' | 'md' | 'lg' | 'xl'
   className?: string
+  labelledBy?: string
 }
 
-export function Modal({ isOpen, onClose, children, size = 'md', className }: ModalProps) {
+export function Modal({ isOpen, onClose, children, size = 'md', className, labelledBy }: ModalProps) {
   const [isAnimating, setIsAnimating] = useState(false)
   const [shouldRender, setShouldRender] = useState(false)
+  const prefersReducedMotion = useReducedMotion()
+  const animationMs = prefersReducedMotion ? 0 : 300
 
   // Handle escape key and prevent scrollbar shift
   useEffect(() => {
@@ -41,21 +45,23 @@ export function Modal({ isOpen, onClose, children, size = 'md', className }: Mod
   useEffect(() => {
     if (isOpen) {
       setShouldRender(true)
-      // Small delay to trigger animation after mounting
-      requestAnimationFrame(() => {
+      if (animationMs === 0) {
+        setIsAnimating(true)
+      } else {
         requestAnimationFrame(() => {
-          setIsAnimating(true)
+          requestAnimationFrame(() => {
+            setIsAnimating(true)
+          })
         })
-      })
+      }
     } else {
       setIsAnimating(false)
-      // Wait for animation to finish before unmounting
       const timer = setTimeout(() => {
         setShouldRender(false)
-      }, 300) // Match animation duration
+      }, animationMs)
       return () => clearTimeout(timer)
     }
-  }, [isOpen])
+  }, [isOpen, animationMs])
 
   if (!shouldRender) return null
 
@@ -63,14 +69,18 @@ export function Modal({ isOpen, onClose, children, size = 'md', className }: Mod
     sm: 'max-w-sm',
     md: 'max-w-md',
     lg: 'max-w-2xl',
+    xl: 'max-w-5xl',
   }
+
+  const durationClass = animationMs === 0 ? 'duration-0' : 'duration-300'
 
   const modalContent = (
     <>
       {/* Backdrop - warm charcoal tint matching mobile nav */}
       <div
         className={cn(
-          'fixed inset-0 z-50 bg-ink-100/50 dark:bg-paper-100/20 transition-opacity duration-300',
+          'fixed inset-0 z-50 bg-ink-100/50 dark:bg-paper-100/20 transition-opacity',
+          durationClass,
           isAnimating ? 'opacity-100' : 'opacity-0'
         )}
         onClick={onClose}
@@ -82,7 +92,8 @@ export function Modal({ isOpen, onClose, children, size = 'md', className }: Mod
         <div
           className={cn(
             'pointer-events-auto w-full bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 shadow-xl',
-            'transform transition-all duration-300',
+            'transform transition-all',
+            durationClass,
             'flex flex-col max-h-[calc(100vh-2rem)] overflow-y-auto',
             isAnimating ? 'opacity-100 scale-100' : 'opacity-0 scale-95',
             sizeClasses[size],
@@ -93,6 +104,7 @@ export function Modal({ isOpen, onClose, children, size = 'md', className }: Mod
           }}
           role="dialog"
           aria-modal="true"
+          aria-labelledby={labelledBy}
         >
           {children}
         </div>
@@ -103,15 +115,17 @@ export function Modal({ isOpen, onClose, children, size = 'md', className }: Mod
   return createPortal(modalContent, document.body)
 }
 
-// Close button component for consistency
+// Close button component for consistency — flow-positioned so content sits below it naturally
 export function ModalClose({ onClose }: { onClose: () => void }) {
   return (
-    <button
-      onClick={onClose}
-      className="absolute top-4 right-4 p-2 rounded-md hover:bg-paper-300 dark:hover:bg-ink-300 transition-smooth focus-ring"
-      aria-label="Close"
-    >
-      <X className="w-5 h-5 text-ink-400 dark:text-paper-300" />
-    </button>
+    <div className="flex justify-end px-4 pt-4">
+      <button
+        onClick={onClose}
+        className="p-2 rounded-md hover:bg-paper-300 dark:hover:bg-ink-300 transition-smooth focus-ring"
+        aria-label="Close"
+      >
+        <X className="w-5 h-5 text-ink-400 dark:text-paper-300" />
+      </button>
+    </div>
   )
 }

--- a/src/hooks/use-reduced-motion.ts
+++ b/src/hooks/use-reduced-motion.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react'
+
+function getReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export function useReducedMotion() {
+  const [reducedMotion, setReducedMotion] = useState(getReducedMotion)
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setReducedMotion(e.matches)
+    }
+
+    handleChange(mediaQuery)
+    mediaQuery.addEventListener('change', handleChange)
+
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  return reducedMotion
+}

--- a/src/pages/readiness.tsx
+++ b/src/pages/readiness.tsx
@@ -7,13 +7,14 @@ import { useSyncStore } from '@/stores/sync-store'
 import { JLPTHero } from '@/components/jlpt/jlpt-hero'
 import { JLPTLevelCard } from '@/components/jlpt/jlpt-level-card'
 import { JLPTLevelDetail } from '@/components/jlpt/jlpt-level-detail'
+import { Modal, ModalClose } from '@/components/shared/modal'
 import type { JoyoGrade } from '@/data/jlpt'
 import { useDocumentTitle } from '@/hooks/use-document-title'
 
 export function Readiness() {
   useDocumentTitle('Readiness')
   const { jlptThreshold } = useSettingsStore()
-  const [expandedLevel, setExpandedLevel] = useState<JoyoGrade | null>(null)
+  const [selectedGrade, setSelectedGrade] = useState<JoyoGrade | null>(null)
   const isSyncing = useSyncStore((state) => state.isSyncing)
 
   // Fetch data
@@ -39,9 +40,14 @@ export function Readiness() {
     return calculateJLPTReadiness(enrichedSubjects, jlptThreshold)
   }, [enrichedSubjects, jlptThreshold])
 
-  // Handle grade expansion
+  // Pre-compute selected grade data so it remains available during the modal close animation
+  const selectedGradeData = useMemo(
+    () => readiness?.grades.find((g) => g.grade === selectedGrade) ?? null,
+    [readiness, selectedGrade]
+  )
+
   const handleToggle = (grade: JoyoGrade) => {
-    setExpandedLevel((current) => (current === grade ? null : grade))
+    setSelectedGrade(grade)
   }
 
   // Loading state - skeleton matching actual content structure
@@ -162,20 +168,28 @@ export function Readiness() {
           <JLPTLevelCard
             key={gradeData.grade}
             data={gradeData}
-            isExpanded={expandedLevel === gradeData.grade}
+            isSelected={selectedGrade === gradeData.grade}
             onToggle={() => handleToggle(gradeData.grade)}
           />
         ))}
       </div>
 
-      {/* Expanded Grade Detail */}
-      {expandedLevel && (
-        <JLPTLevelDetail
-          data={readiness.grades.find((g) => g.grade === expandedLevel)!}
-          subjects={enrichedSubjects}
-          threshold={jlptThreshold}
-        />
-      )}
+      {/* Grade Detail Modal */}
+      <Modal
+        isOpen={selectedGrade !== null}
+        onClose={() => setSelectedGrade(null)}
+        size="xl"
+        labelledBy="jlpt-level-detail-title"
+      >
+        <ModalClose onClose={() => setSelectedGrade(null)} />
+        {selectedGradeData && (
+          <JLPTLevelDetail
+            data={selectedGradeData}
+            subjects={enrichedSubjects}
+            threshold={jlptThreshold}
+          />
+        )}
+      </Modal>
 
       {/* Footer Info */}
       <div className="bg-paper-200 dark:bg-ink-200 rounded-lg border border-paper-300 dark:border-ink-300 p-6">


### PR DESCRIPTION
## Context

This PR addresses the same UX problem raised in #44 by @keithajohnson: when a grade tile is expanded on the Readiness page, the detail panel renders below the entire card grid. For lower tiles (Grade 4 and beyond) the newly revealed content appears off-screen with no visual cue, making it look like nothing happened.

Credit to Keith for identifying and reporting the issue clearly -- the problem description in #44 directly informed this fix.

## Approach

Rather than scrolling the page to the expanded panel, this PR solves the problem at the layout level by opening `JLPTLevelDetail` inside the existing `Modal` component when a grade card is clicked. The detail is immediately visible regardless of which card triggered it, and the Secondary School grade (~1,130 kanji) is handled naturally via the modal's internal scroll.

This reuses infrastructure that already exists in the codebase (`Modal`, portal, escape key, scroll-lock, backdrop) rather than introducing new scroll logic.

## Changes

**New**
- `src/hooks/use-reduced-motion.ts` -- reactive hook following the `use-mobile.ts` matchMedia + change-listener pattern; used by Modal so the preference is handled consistently in one place

**Modified**
- `src/components/shared/modal.tsx` -- adds `xl` size (`max-w-5xl`), `aria-labelledby` support, and reduced-motion-aware animation timing (duration and unmount delay both respond to the hook); fixes `ModalClose` to be flow-positioned rather than `absolute` so it cannot overlap content
- `src/components/jlpt/jlpt-level-detail.tsx` -- strips the outer card chrome (the Modal provides the wrapper); adds `id` to the heading for `aria-labelledby`
- `src/components/jlpt/jlpt-level-card.tsx` -- renames `isExpanded` to `isSelected`; swaps `ChevronDown` for `ArrowUpRight` to signal drill-in rather than expand-below; highlights the active card with a vermillion border while the modal is open
- `src/pages/readiness.tsx` -- `selectedGrade` state drives modal open/close; `selectedGradeData` memo retains the last grade's data during the close animation so there is no content flash

## What this does not change

- No scroll hacks, magic offsets, or `requestAnimationFrame` timing workarounds
- No new routing conventions
- Filter state inside the detail resets naturally on each open (component unmounts with the modal)
- `ConfirmDialog` and `DrilldownModal` are unaffected; neither uses `ModalClose`

## Test plan

- [x] Click each of the 7 grade cards -- modal opens immediately with correct content
- [ ] Click backdrop, press Escape, click X -- modal closes cleanly
- [ ] Filter buttons (All / Known / Unknown) inside the modal work correctly
- [ ] Secondary School grade (~1,130 kanji) opens without overflowing the viewport; modal scrolls internally
- [ ] Chrome DevTools -> Rendering -> "Emulate CSS media feature prefers-reduced-motion: reduce" -- modal opens and closes instantly with no animation
- [ ] Dark mode -- modal colors correct
- [ ] Mobile viewport -- modal fills width sensibly; kanji grid breakpoints render correctly inside the modal
- [ ] Keyboard: Tab navigates within modal; Escape closes