### PR TITLE
Housekeeping: sync correctness, rate limiter, logging, LICENSE, PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # No lint step: `npm run lint` is currently broken (eslint is not a
+      # dependency and there is no eslint config). Add it here once that's
+      # fixed. Tests are tracked in #47.
+
+      - name: Build
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to WaniTrack will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.20.1] - 2026-06-09
+
+### Fixed
+- **Sync: Delta Sync Could Miss Updates That Landed Mid-Sync**: The delta sync cursor now uses the WaniKani collection's own `data_updated_at` timestamp instead of a client-clock timestamp recorded after the fetch finished
+  - Previously, anything updated server-side *while* a long sync was running fell into a gap between the data actually fetched and the recorded sync time, and was silently skipped by every subsequent delta sync; client clock skew widened the gap
+  - If the API response carries no `data_updated_at`, the client falls back to a timestamp captured *before* the fetch started — over-fetching on the next delta is harmless since writes are idempotent
+- **Sync: Rate Limiter Could Burst Past WaniKani's Limit During Parallel Sync**: Since 2.19.2, assignments, review statistics, and level progressions sync concurrently, and simultaneous requests could each read the same "last request time" and fire at once; requests now reserve serialized 1-second slots, so concurrent callers queue correctly
+  - The client also now retries on HTTP 429 responses, honouring the `Retry-After` header (up to 3 attempts) instead of failing the sync outright
+
+### Changed
+- **Debug Logging No Longer Ships to Production**: `[SYNC]`/`[REPO]` console logs in the sync path now emit only in dev builds; warnings and errors for real failures are unchanged
+
+### Technical
+- Replaced `RateLimiter` in `src/lib/api/client.ts` with a slot-reservation queue: the next available slot is claimed synchronously (no `await` between read and write), so concurrent callers cannot race; a `backOff()` hook pushes pending slots past a server-requested `Retry-After` window
+- `apiRequest()` now retries 429 responses (parsing `Retry-After` as delay-seconds or HTTP-date, 2s default, max 3 retries) before surfacing a `WaniKaniAPIError`
+- Added `fetchAllPagesWithMeta()` to `src/lib/api/client.ts`, returning `{ data, dataUpdatedAt }` where `dataUpdatedAt` is the latest collection `data_updated_at` seen across pages; `fetchSubjects()`, `fetchAssignments()`, `fetchReviewStatistics()`, and `fetchLevelProgressions()` now return this shape, and the four repositories store `dataUpdatedAt ?? fetchStartedAt` as their delta cursor (also removed the `: any` casts in the repository `map()` callbacks, since ids are now typed on the result)
+- Removed the stale `fetchSubjectsWithFilter()` wrapper (and its leftover "Phase 4" planning comment) from `src/lib/db/repositories/subjects.ts`; `fetchSubjects()` is called directly
+- Added `src/lib/utils/debug-log.ts`: `debugLog()` gates `console.log` behind `import.meta.env.DEV`
+- Added MIT `LICENSE` file (the README already declared MIT, but without the file the code was technically all-rights-reserved)
+- Added `.github/workflows/ci.yml`: pull requests now run `npm ci`, `npm run typecheck`, and `npm run build`. The `lint` script is **not** included because it is currently broken — `eslint` is not a dependency and no eslint config exists in the repo; tests are tracked separately in #47
+
 ## [2.20.0] - 2026-05-19
 
 ### Changed
@@ -1463,6 +1484,7 @@ WaniTrack v2.0.0 - Complete WaniKani statistics tracker and analytics platform.
 
 ## Version History Summary
 
+- **2.20.1** (Jun 9, 2026) - Delta sync cursor from server data_updated_at; concurrency-safe rate limiter with 429 retry; dev-only sync logging; MIT LICENSE file; PR CI workflow
 - **2.20.0** (May 19, 2026) - Readiness grade detail opens in modal; useReducedMotion hook; Modal xl size, aria-labelledby, reduced-motion-aware animation
 - **2.19.3** (Apr 10, 2026) - Accuracy by Level weighted calculation fix; hidden items excluded; kana_vocabulary/radical reading handling corrected
 - **2.19.2** (Mar 3, 2026) - Level 60 Projection completed-levels count correct after reset

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tyler Cartwright
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive analytics platform for WaniKani learners. Track your progress, identify problem areas, and optimize your kanji and vocabulary study with detailed insights—all processed locally in your browser.
 
-**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.20.0
+**Live App:** [wanitrack.com](https://wanitrack.com) | **Version:** 2.20.1
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wanitrack",
-  "version": "2.19.3",
+  "version": "2.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wanitrack",
-      "version": "2.19.3",
+      "version": "2.20.1",
       "dependencies": {
         "@tanstack/react-query": "^5.90.11",
         "clsx": "^2.1.1",
@@ -2828,6 +2828,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wanitrack",
   "private": true,
-  "version": "2.20.0",
+  "version": "2.20.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -13,27 +13,54 @@ const BASE_URL = 'https://api.wanikani.com/v2'
 // We'll be conservative and limit to 1 request per second (60/min)
 const MIN_REQUEST_INTERVAL = 1000 // milliseconds
 
+// 429 handling
+const MAX_RATE_LIMIT_RETRIES = 3
+const DEFAULT_RETRY_AFTER_MS = 2000
+
 // ============================================================================
 // Rate Limiter
 // ============================================================================
 
 class RateLimiter {
-  private lastRequestTime = 0
+  private nextSlotTime = 0
 
   async waitIfNeeded(): Promise<void> {
+    // Reserve the next available slot synchronously (no await between read
+    // and write), so concurrent callers each get a distinct slot instead of
+    // racing on a shared "last request" timestamp.
     const now = Date.now()
-    const timeSinceLastRequest = now - this.lastRequestTime
+    const slot = Math.max(now, this.nextSlotTime)
+    this.nextSlotTime = slot + MIN_REQUEST_INTERVAL
 
-    if (timeSinceLastRequest < MIN_REQUEST_INTERVAL) {
-      const waitTime = MIN_REQUEST_INTERVAL - timeSinceLastRequest
-      await new Promise(resolve => setTimeout(resolve, waitTime))
+    if (slot > now) {
+      await new Promise(resolve => setTimeout(resolve, slot - now))
     }
+  }
 
-    this.lastRequestTime = Date.now()
+  /** Push all pending slots back, e.g. after the server tells us to slow down. */
+  backOff(durationMs: number): void {
+    this.nextSlotTime = Math.max(this.nextSlotTime, Date.now() + durationMs)
   }
 }
 
 const rateLimiter = new RateLimiter()
+
+/**
+ * Parse a Retry-After header (delay-seconds or HTTP-date) into milliseconds
+ */
+function parseRetryAfter(header: string | null): number {
+  if (header) {
+    const seconds = Number(header)
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return seconds * 1000
+    }
+    const date = Date.parse(header)
+    if (!Number.isNaN(date) && date > Date.now()) {
+      return date - Date.now()
+    }
+  }
+  return DEFAULT_RETRY_AFTER_MS
+}
 
 // ============================================================================
 // API Client
@@ -57,62 +84,84 @@ export async function apiRequest<T>(
   endpoint: string,
   token: string
 ): Promise<T> {
-  // Wait if needed to respect rate limits
-  await rateLimiter.waitIfNeeded()
-
   const url = endpoint.startsWith('http') ? endpoint : `${BASE_URL}${endpoint}`
 
-  try {
-    const response = await fetch(url, {
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Wanikani-Revision': '20170710', // API revision date
-      },
-    })
+  for (let attempt = 0; ; attempt++) {
+    // Wait if needed to respect rate limits
+    await rateLimiter.waitIfNeeded()
 
-    if (!response.ok) {
-      let errorMessage = `API request failed: ${response.status} ${response.statusText}`
-      let errorCode: number | undefined
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Wanikani-Revision': '20170710', // API revision date
+        },
+      })
 
-      try {
-        const errorData: APIError = await response.json()
-        errorMessage = errorData.error || errorMessage
-        errorCode = errorData.code
-      } catch {
-        // If we can't parse the error response, use the default message
+      if (response.status === 429 && attempt < MAX_RATE_LIMIT_RETRIES) {
+        const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'))
+        console.warn(
+          `WaniKani rate limit hit (429); retrying in ${retryAfterMs}ms (attempt ${attempt + 1}/${MAX_RATE_LIMIT_RETRIES})`
+        )
+        rateLimiter.backOff(retryAfterMs)
+        continue
       }
 
-      throw new WaniKaniAPIError(errorMessage, response.status, errorCode)
-    }
+      if (!response.ok) {
+        let errorMessage = `API request failed: ${response.status} ${response.statusText}`
+        let errorCode: number | undefined
 
-    const data = await response.json()
-    return data as T
-  } catch (error) {
-    if (error instanceof WaniKaniAPIError) {
-      throw error
-    }
+        try {
+          const errorData: APIError = await response.json()
+          errorMessage = errorData.error || errorMessage
+          errorCode = errorData.code
+        } catch {
+          // If we can't parse the error response, use the default message
+        }
 
-    // Network errors or other issues
-    throw new WaniKaniAPIError(
-      error instanceof Error ? error.message : 'Unknown error occurred',
-      0
-    )
+        throw new WaniKaniAPIError(errorMessage, response.status, errorCode)
+      }
+
+      const data = await response.json()
+      return data as T
+    } catch (error) {
+      if (error instanceof WaniKaniAPIError) {
+        throw error
+      }
+
+      // Network errors or other issues
+      throw new WaniKaniAPIError(
+        error instanceof Error ? error.message : 'Unknown error occurred',
+        0
+      )
+    }
   }
 }
 
+export interface PaginatedFetchResult<T> {
+  data: (T & { id: number })[]
+  /**
+   * The collection's data_updated_at: the server-side timestamp of the most
+   * recently updated resource in the collection (null when the collection is
+   * empty). Use this as the next delta sync's updated_after cursor.
+   */
+  dataUpdatedAt: string | null
+}
+
 /**
- * Fetch all pages of a paginated collection
+ * Fetch all pages of a paginated collection, plus the collection's
+ * data_updated_at timestamp
  * WaniKani uses cursor-based pagination with next_url
  * Returns data with id merged in for easier access
  */
-export async function fetchAllPages<T>(
+export async function fetchAllPagesWithMeta<T>(
   initialEndpoint: string,
   token: string,
   onProgress?: (current: number, total: number) => void
-): Promise<(T & { id: number })[]> {
+): Promise<PaginatedFetchResult<T>> {
   const allData: (T & { id: number })[] = []
+  let dataUpdatedAt: string | null = null
   let nextUrl: string | null = initialEndpoint
-  let pageCount = 0
 
   while (nextUrl) {
     const collection: Collection<T> = await apiRequest<Collection<T>>(nextUrl, token)
@@ -124,7 +173,12 @@ export async function fetchAllPages<T>(
     }))
     allData.push(...pageData)
 
-    pageCount++
+    // Keep the latest data_updated_at seen across pages (ISO 8601 UTC
+    // strings, so lexicographic comparison is chronological)
+    if (collection.data_updated_at &&
+        (!dataUpdatedAt || collection.data_updated_at > dataUpdatedAt)) {
+      dataUpdatedAt = collection.data_updated_at
+    }
 
     // Report progress if callback provided
     if (onProgress && collection.total_count > 0) {
@@ -135,7 +189,19 @@ export async function fetchAllPages<T>(
     nextUrl = collection.pages.next_url
   }
 
-  return allData
+  return { data: allData, dataUpdatedAt }
+}
+
+/**
+ * Fetch all pages of a paginated collection (data only)
+ */
+export async function fetchAllPages<T>(
+  initialEndpoint: string,
+  token: string,
+  onProgress?: (current: number, total: number) => void
+): Promise<(T & { id: number })[]> {
+  const result = await fetchAllPagesWithMeta<T>(initialEndpoint, token, onProgress)
+  return result.data
 }
 
 /**

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -1,7 +1,8 @@
 // WaniKani API v2 Endpoints
 // Typed functions for each API resource
 
-import { fetchResource, fetchAllPages } from './client'
+import { fetchResource, fetchAllPages, fetchAllPagesWithMeta } from './client'
+import type { PaginatedFetchResult } from './client'
 import type {
   User,
   Assignment,
@@ -29,7 +30,7 @@ export async function fetchUser(token: string): Promise<User> {
 // ============================================================================
 
 /**
- * Fetch all assignments for the user
+ * Fetch all assignments for the user, plus the collection's data_updated_at
  * Handles pagination automatically
  * https://docs.api.wanikani.com/20170710/#get-all-assignments
  */
@@ -37,13 +38,13 @@ export async function fetchAssignments(
   token: string,
   updatedAfter?: string,
   onProgress?: (current: number, total: number) => void
-): Promise<(Assignment & { id: number })[]> {
+): Promise<PaginatedFetchResult<Assignment>> {
   const params = new URLSearchParams()
   if (updatedAfter) {
     params.append('updated_after', updatedAfter)
   }
   const endpoint = params.toString() ? `/assignments?${params}` : '/assignments'
-  return fetchAllPages<Assignment>(endpoint, token, onProgress)
+  return fetchAllPagesWithMeta<Assignment>(endpoint, token, onProgress)
 }
 
 /**
@@ -90,7 +91,8 @@ export async function fetchAssignmentsFiltered(
 // ============================================================================
 
 /**
- * Fetch all subjects (radicals, kanji, vocabulary)
+ * Fetch all subjects (radicals, kanji, vocabulary), plus the collection's
+ * data_updated_at
  * Handles pagination automatically
  * https://docs.api.wanikani.com/20170710/#get-all-subjects
  */
@@ -98,13 +100,13 @@ export async function fetchSubjects(
   token: string,
   updatedAfter?: string,
   onProgress?: (current: number, total: number) => void
-): Promise<(Subject & { id: number })[]> {
+): Promise<PaginatedFetchResult<Subject>> {
   const params = new URLSearchParams()
   if (updatedAfter) {
     params.append('updated_after', updatedAfter)
   }
   const endpoint = params.toString() ? `/subjects?${params}` : '/subjects'
-  return fetchAllPages<Subject>(endpoint, token, onProgress)
+  return fetchAllPagesWithMeta<Subject>(endpoint, token, onProgress)
 }
 
 /**
@@ -146,20 +148,20 @@ export async function fetchSubjectsFiltered(
 // ============================================================================
 
 /**
- * Fetch all level progressions
+ * Fetch all level progressions, plus the collection's data_updated_at
  * https://docs.api.wanikani.com/20170710/#get-all-level-progressions
  */
 export async function fetchLevelProgressions(
   token: string,
   updatedAfter?: string,
   onProgress?: (current: number, total: number) => void
-): Promise<(LevelProgression & { id: number })[]> {
+): Promise<PaginatedFetchResult<LevelProgression>> {
   const params = new URLSearchParams()
   if (updatedAfter) {
     params.append('updated_after', updatedAfter)
   }
   const endpoint = params.toString() ? `/level_progressions?${params}` : '/level_progressions'
-  return fetchAllPages<LevelProgression>(endpoint, token, onProgress)
+  return fetchAllPagesWithMeta<LevelProgression>(endpoint, token, onProgress)
 }
 
 // ============================================================================
@@ -181,20 +183,20 @@ export async function fetchResets(
 // ============================================================================
 
 /**
- * Fetch all review statistics
+ * Fetch all review statistics, plus the collection's data_updated_at
  * https://docs.api.wanikani.com/20170710/#get-all-review-statistics
  */
 export async function fetchReviewStatistics(
   token: string,
   updatedAfter?: string,
   onProgress?: (current: number, total: number) => void
-): Promise<(ReviewStatistic & { id: number })[]> {
+): Promise<PaginatedFetchResult<ReviewStatistic>> {
   const params = new URLSearchParams()
   if (updatedAfter) {
     params.append('updated_after', updatedAfter)
   }
   const endpoint = params.toString() ? `/review_statistics?${params}` : '/review_statistics'
-  return fetchAllPages<ReviewStatistic>(endpoint, token, onProgress)
+  return fetchAllPagesWithMeta<ReviewStatistic>(endpoint, token, onProgress)
 }
 
 /**

--- a/src/lib/db/repositories/assignments.ts
+++ b/src/lib/db/repositories/assignments.ts
@@ -33,7 +33,10 @@ export async function syncAssignments(
 
   onProgress?.(isFullSync ? 'Fetching all assignments...' : 'Checking for assignment updates...')
 
-  const assignments = await fetchAssignments(token, updatedAfter ?? undefined)
+  // Fallback delta cursor if the API response carries no data_updated_at;
+  // captured before the fetch so updates landing mid-sync aren't skipped
+  const fetchStartedAt = new Date().toISOString()
+  const { data: assignments, dataUpdatedAt } = await fetchAssignments(token, updatedAfter ?? undefined)
 
   if (assignments.length === 0) {
     onProgress?.('Assignments up to date')
@@ -42,10 +45,7 @@ export async function syncAssignments(
 
   onProgress?.(`Saving ${assignments.length} assignments...`)
 
-  // Need to extract ID from the fetched data
-  // Note: fetchAssignments returns Assignment[], but we need IDs
-  // See Phase 4 for API modifications
-  const cachedAssignments: CachedAssignment[] = assignments.map((assignment: any) => ({
+  const cachedAssignments: CachedAssignment[] = assignments.map((assignment) => ({
     id: assignment.id,
     subjectId: assignment.subject_id,
     data: assignment,
@@ -54,8 +54,9 @@ export async function syncAssignments(
 
   await putMany(STORES.ASSIGNMENTS, cachedAssignments)
 
+  // Update sync metadata using the server-side collection timestamp
   await updateSyncMetadata({
-    assignmentsUpdatedAt: new Date().toISOString(),
+    assignmentsUpdatedAt: dataUpdatedAt ?? fetchStartedAt,
   })
 
   onProgress?.(`Updated ${assignments.length} assignments`)

--- a/src/lib/db/repositories/level-progressions.ts
+++ b/src/lib/db/repositories/level-progressions.ts
@@ -35,7 +35,10 @@ export async function syncLevelProgressions(
     isFullSync ? 'Fetching level progressions...' : 'Checking for level progression updates...'
   )
 
-  const progressions = await fetchLevelProgressions(token, updatedAfter ?? undefined)
+  // Fallback delta cursor if the API response carries no data_updated_at;
+  // captured before the fetch so updates landing mid-sync aren't skipped
+  const fetchStartedAt = new Date().toISOString()
+  const { data: progressions, dataUpdatedAt } = await fetchLevelProgressions(token, updatedAfter ?? undefined)
 
   if (progressions.length === 0) {
     onProgress?.('Level progressions up to date')
@@ -44,7 +47,7 @@ export async function syncLevelProgressions(
 
   onProgress?.(`Saving ${progressions.length} level progressions...`)
 
-  const cachedProgressions: CachedLevelProgression[] = progressions.map((prog: any) => ({
+  const cachedProgressions: CachedLevelProgression[] = progressions.map((prog) => ({
     id: prog.id,
     level: prog.level,
     data: prog,
@@ -53,8 +56,9 @@ export async function syncLevelProgressions(
 
   await putMany(STORES.LEVEL_PROGRESSIONS, cachedProgressions)
 
+  // Update sync metadata using the server-side collection timestamp
   await updateSyncMetadata({
-    levelProgressionsUpdatedAt: new Date().toISOString(),
+    levelProgressionsUpdatedAt: dataUpdatedAt ?? fetchStartedAt,
   })
 
   onProgress?.(`Updated ${progressions.length} level progressions`)

--- a/src/lib/db/repositories/review-statistics.ts
+++ b/src/lib/db/repositories/review-statistics.ts
@@ -35,7 +35,10 @@ export async function syncReviewStatistics(
     isFullSync ? 'Fetching all review statistics...' : 'Checking for review statistic updates...'
   )
 
-  const stats = await fetchReviewStatistics(token, updatedAfter ?? undefined)
+  // Fallback delta cursor if the API response carries no data_updated_at;
+  // captured before the fetch so updates landing mid-sync aren't skipped
+  const fetchStartedAt = new Date().toISOString()
+  const { data: stats, dataUpdatedAt } = await fetchReviewStatistics(token, updatedAfter ?? undefined)
 
   if (stats.length === 0) {
     onProgress?.('Review statistics up to date')
@@ -44,7 +47,7 @@ export async function syncReviewStatistics(
 
   onProgress?.(`Saving ${stats.length} review statistics...`)
 
-  const cachedStats: CachedReviewStatistic[] = stats.map((stat: any) => ({
+  const cachedStats: CachedReviewStatistic[] = stats.map((stat) => ({
     id: stat.id,
     subjectId: stat.subject_id,
     data: stat,
@@ -53,8 +56,9 @@ export async function syncReviewStatistics(
 
   await putMany(STORES.REVIEW_STATISTICS, cachedStats)
 
+  // Update sync metadata using the server-side collection timestamp
   await updateSyncMetadata({
-    reviewStatisticsUpdatedAt: new Date().toISOString(),
+    reviewStatisticsUpdatedAt: dataUpdatedAt ?? fetchStartedAt,
   })
 
   onProgress?.(`Updated ${stats.length} review statistics`)

--- a/src/lib/db/repositories/subjects.ts
+++ b/src/lib/db/repositories/subjects.ts
@@ -3,6 +3,7 @@ import { getAll, putMany, count } from '../database'
 import { STORES } from '../schema'
 import { getSyncMetadata, updateSyncMetadata } from '../sync-metadata'
 import { fetchSubjects } from '@/lib/api/endpoints'
+import { debugLog } from '@/lib/utils/debug-log'
 import type { Subject } from '@/lib/api/types'
 
 export interface CachedSubject {
@@ -24,22 +25,23 @@ export async function syncSubjects(
   token: string,
   onProgress?: (message: string) => void
 ): Promise<{ updated: number; isFullSync: boolean }> {
-  console.log('[REPO] syncSubjects started')
+  debugLog('[REPO] syncSubjects started')
   const metadata = await getSyncMetadata()
   const cachedCount = await getSubjectCount()
-  console.log('[REPO] Subjects - cached count:', cachedCount, 'metadata:', metadata.subjectsUpdatedAt)
+  debugLog('[REPO] Subjects - cached count:', cachedCount, 'metadata:', metadata.subjectsUpdatedAt)
 
   // Determine if we need a full sync or delta sync
   const isFullSync = cachedCount === 0 || !metadata.subjectsUpdatedAt
   const updatedAfter = isFullSync ? undefined : metadata.subjectsUpdatedAt
-  console.log('[REPO] Subjects - isFullSync:', isFullSync, 'updatedAfter:', updatedAfter)
+  debugLog('[REPO] Subjects - isFullSync:', isFullSync, 'updatedAfter:', updatedAfter)
 
   onProgress?.(isFullSync ? 'Fetching all subjects...' : 'Checking for subject updates...')
 
-  // Build endpoint with updated_after if doing delta sync
-  console.log('[REPO] Calling fetchSubjectsWithFilter...')
-  const subjects = await fetchSubjectsWithFilter(token, updatedAfter)
-  console.log('[REPO] Fetched subjects count:', subjects.length)
+  // Fallback delta cursor if the API response carries no data_updated_at;
+  // captured before the fetch so updates landing mid-sync aren't skipped
+  const fetchStartedAt = new Date().toISOString()
+  const { data: subjects, dataUpdatedAt } = await fetchSubjects(token, updatedAfter ?? undefined)
+  debugLog('[REPO] Fetched subjects count:', subjects.length)
 
   if (subjects.length === 0) {
     onProgress?.('Subjects up to date')
@@ -57,21 +59,11 @@ export async function syncSubjects(
 
   await putMany(STORES.SUBJECTS, cachedSubjects)
 
-  // Update sync metadata
+  // Update sync metadata using the server-side collection timestamp
   await updateSyncMetadata({
-    subjectsUpdatedAt: new Date().toISOString(),
+    subjectsUpdatedAt: dataUpdatedAt ?? fetchStartedAt,
   })
 
   onProgress?.(`Updated ${subjects.length} subjects`)
   return { updated: subjects.length, isFullSync }
-}
-
-// Helper to fetch with updated_after filter
-async function fetchSubjectsWithFilter(
-  token: string,
-  updatedAfter?: string | null
-): Promise<(Subject & { id: number })[]> {
-  // Note: This requires modifying fetchSubjects to accept updated_after
-  // See Phase 4 for API layer updates
-  return fetchSubjects(token, updatedAfter ?? undefined)
 }

--- a/src/lib/sync/sync-manager.ts
+++ b/src/lib/sync/sync-manager.ts
@@ -5,6 +5,7 @@ import { syncReviewStatistics } from '@/lib/db/repositories/review-statistics'
 import { syncLevelProgressions } from '@/lib/db/repositories/level-progressions'
 import { updateSyncMetadata, getSyncMetadata } from '@/lib/db/sync-metadata'
 import { clearDatabase } from '@/lib/db/database'
+import { debugLog } from '@/lib/utils/debug-log'
 
 export interface SyncProgress {
   phase: 'idle' | 'subjects' | 'assignments' | 'reviewStats' | 'levelProgressions' | 'complete' | 'error'
@@ -31,7 +32,7 @@ export async function performSync(
   token: string,
   onProgress?: SyncProgressCallback
 ): Promise<SyncResult> {
-  console.log('[SYNC] performSync started with token:', token ? 'present' : 'missing')
+  debugLog('[SYNC] performSync started with token:', token ? 'present' : 'missing')
 
   const result: SyncResult = {
     success: false,
@@ -44,7 +45,7 @@ export async function performSync(
 
   try {
     // Sync subjects first (they're the foundation)
-    console.log('[SYNC] Starting subjects sync...')
+    debugLog('[SYNC] Starting subjects sync...')
     onProgress?.({ phase: 'subjects', message: 'Syncing subjects...', isFullSync: false })
     const subjectsResult = await syncSubjects(token, (msg) =>
       onProgress?.({ phase: 'subjects', message: msg, isFullSync: false })

--- a/src/lib/utils/debug-log.ts
+++ b/src/lib/utils/debug-log.ts
@@ -1,0 +1,7 @@
+// Debug logging that only emits in dev builds.
+// Use for diagnostic noise; real failures should use console.error/warn.
+export function debugLog(...args: unknown[]): void {
+  if (import.meta.env.DEV) {
+    console.log(...args)
+  }
+}


### PR DESCRIPTION
Closes #46

Works through all six items from the issue. Version bumped to 2.20.1.

## 1. Delta-sync timestamp gap

The four repositories now store the WaniKani collection's own `data_updated_at` as the delta cursor instead of a client-clock timestamp recorded after the fetch. `fetchAllPagesWithMeta()` in `client.ts` tracks the latest `data_updated_at` seen across pages and returns it alongside the data; the four sync endpoints (`fetchSubjects`, `fetchAssignments`, `fetchReviewStatistics`, `fetchLevelProgressions`) return this shape. If the API ever returns no `data_updated_at`, the repos fall back to a timestamp captured *before* the fetch started — over-fetching on the next delta is harmless since puts are idempotent. The zero-results early-return path is unchanged (no updates means the existing cursor is still valid).

## 2. Rate limiter + 429 handling

Replaced the read-modify-write `lastRequestTime` limiter with a slot-reservation queue: each caller claims the next 1-second slot **synchronously** (no `await` between reading and advancing `nextSlotTime`), so the parallel syncs from #41 can no longer read the same state and burst simultaneously.

I looked at the token bucket in closed PR #40 as suggested — it has the same read-modify-write race under concurrency (refill check and token decrement aren't coordinated across concurrent waiters), and its burst-of-5 behaviour is the part that was met with skepticism when #40 was closed. So I kept the conservative strict 1 req/s pacing, just made it correct under concurrency.

`apiRequest()` now also retries 429s up to 3 times, honouring `Retry-After` (delay-seconds or HTTP-date; 2s default when absent) and pushing the limiter's pending slots past the retry window so other queued requests don't immediately re-trigger it.

## 3. Debug logging

`[SYNC]`/`[REPO]` console.logs in `sync-manager.ts` and the repositories now go through a tiny `debugLog()` util (`src/lib/utils/debug-log.ts`) gated behind `import.meta.env.DEV`. `console.warn`/`console.error` for real failures are untouched. Scope kept to the sync path per the issue — other `[USE-SYNC]`/`[EXPORT]`/`[VERSION]` logs elsewhere were left alone.

## 4. LICENSE

Added MIT LICENSE, copyright Tyler Cartwright (2025, year of first commit). README already claimed MIT.

## 5. PR CI

Added `.github/workflows/ci.yml` running `npm ci`, `npm run typecheck`, and `npm run build` on pull requests. `deploy.yml` untouched. No test step yet (#47).

⚠️ **Lint is not in CI because `npm run lint` is currently broken**: `eslint` is not in `devDependencies` and there is no eslint config anywhere in the repo, so the script fails with `eslint: command not found`. Per the issue's spirit I didn't silently add an opinionated config — the workflow has a comment marking where the lint step should go once eslint is actually set up (could be a small follow-up issue).

## 6. Stale wrapper

Deleted `fetchSubjectsWithFilter` and its "Phase 4" comment; `syncSubjects` calls `fetchSubjects` directly. Also dropped the now-unneeded `: any` casts in the repository `map()` callbacks, since ids are typed on the fetch result.

## Checks

- `npm run typecheck` — passes
- `npm run build` — passes (tsc -b + vite build + PWA generation)
- `npm run lint` — fails (`eslint: command not found`, pre-existing; see above)