### PR TITLE
docs(strategy): competitive refresh and roadmap through 2.29

### DIFF
--- a/.docs/PRODUCT_STRATEGY.md
+++ b/.docs/PRODUCT_STRATEGY.md
@@ -7,6 +7,12 @@
 > **Updated 2026-06-09**: added §6 (PWA/offline audit) after discovering the
 > offline story is broken in ways that block the activity-history plan; roadmap
 > re-sequenced — "Solid ground" now precedes "The flight recorder".
+>
+> **Updated 2026-06-12**: competitive research refresh at v2.24.0 (2.21–2.24 all
+> shipped). §2 competitor table rebuilt — Wanilog has expanded substantially.
+> New §2.1 user-request log from our community thread. §7 roadmap extended
+> through 2.29: 2.25 leech trainer confirmed, then Real JLPT → "Can I read
+> this?" → projections overhaul → demo mode/SEO.
 
 ---
 
@@ -14,7 +20,7 @@
 
 ### Where the product stands
 
-- Seven feature pages: Dashboard, Progress, Accuracy, Forecast, Leeches, Kanji Grid, Readiness.
+- Eight feature pages: Dashboard, Progress, Activity (added 2.23), Accuracy, Forecast, Leeches, Kanji Grid, Readiness.
 - Recent releases (2.17–2.20.x) shifted from feature-building to correctness and
   polish: reset handling via `/resets`, weighted accuracy matching WKStats, sync
   race fixes, CI workflow. Solid foundation.
@@ -42,32 +48,55 @@ switching cost for users. Most recommendations below orbit this fact.
 
 - No backend; local-first and privacy-focused is a selling point — keep it.
 - WaniKani API: 60 req/min, app is read-only against it.
-- Solo maintainer; no test suite yet (#47), no eslint. Prefer high
-  value-to-maintenance ratio.
+- Solo maintainer; test suite landed in 2.21 (#47 closed), no eslint. Prefer
+  high value-to-maintenance ratio.
 
 ---
 
-## 2. Competitive landscape (as researched June 2026)
+## 2. Competitive landscape (re-researched 2026-06-12 at v2.24.0)
 
 | Competitor | What they have that we don't | Weakness |
 |---|---|---|
-| **wkstats.com** | Items grouped by JLPT/Jōyō/**frequency**; canonical brand | Stale, desktop-era UI, lost review history when API died, no workload forecast, no leech tools |
-| **Wanilog** ⚠️ *primary threat* | **Leech trainer** (flashcard quiz), **share cards** (Wrapped-style images), **achievements/medals**, **reading coverage** (top-2,500 kanji, NHK Easy), Japanese UI, themes | Newer, smaller mindshare; same local-first model, so no data moat either |
-| **Heatmap userscript** | Daily activity heatmap + streaks (forward-only, recorded in-page) | Desktop Tampermonkey only; invisible to mobile/PWA users |
+| **Wanilog** ⚠️ *primary threat* | **Leech trainer** (full-screen flashcards, tap-to-flip, self-grade, auto audio on reveal, **three selectable scoring algorithms**); **"Can I read this?"** paste-text readability analyzer (gap characters highlighted); **direct JLPT N5–N1 coverage with drill-down**; live NHK-headlines reading coverage (Best coverage / Best for learning / Most recent filters); statistical projections with **confidence intervals**, goal level/date, **what-if pace slider**; **standalone calculator suite** as SEO landing pages (level-by-date, daily review budget, vacation impact, queue burndown, reset recovery, JLPT countdown, burn time); **demo mode** (try without a token); achievements/medals; manual known-kanji input; "effective accuracy" (meaning × reading); Japanese UI, 4 palettes; cinematic 1→60 replay; a **comparison landing page vs wkstats** | Smaller mindshare; **no historical activity capture** — no heatmap, no streaks-over-time, no data moat. Optional server features (public profiles, achievement sync) dilute their privacy pitch. Walked back NHK Easy integration as unreliable — external-content maintenance burden is real |
+| **wkstats.com** | Items grouped by JLPT/Jōyō/**frequency**; canonical brand (still the first name people search) | v2 projections never finished; stale, desktop-era UI; lost review history when API died; no workload forecast, no leech tools. Fading — Wanilog markets directly against it |
+| **Heatmap userscript (Kumirei)** | Per-day **drill-down to item level** (SRS, type, accuracy), time-spent estimates, level-up markers on calendar, configurable color intervals/themes | Desktop Tampermonkey only; invisible to mobile/PWA users |
 | **Item Inspector userscript** | Deeply configurable item tables, leech filters, export | Userscript-only, notoriously complex UI |
+| **Self-Study Quiz / Extra Practice userscripts** | Quiz over **arbitrary filtered item sets** (recently failed, current level, custom lists) | Userscript-only; recurring community wish for this off-desktop |
 | **Ultimate Timeline 2 userscript** | Hour-by-hour review timeline | We already have review forecast; userscript-only |
-| **Tsurukame / Flaming Durtles** | Offline reviews/lessons (review clients — different category) | Stats are an afterthought |
+| **Tsurukame / Smouldering Durtles** | Offline reviews/lessons (review clients — different category); Smouldering Durtles bundles a self-study quiz | Stats are an afterthought |
 | **BishBashBosh** | Cram quiz for Apprentice-1 items + recent failures | Single-purpose, dated |
 
 Userscripts are less a threat than a roadmap: they prove demand for features
 that only reach desktop userscript users; we can bring them to everyone,
 mobile included.
 
+**Positioning (June 2026)**: Wanilog wins on breadth and acquisition surface
+(calculators-as-SEO, demo mode, comparison pages); a solo maintainer cannot
+out-feature them release-for-release. We win by (a) owning the historical-data
+axis they structurally lack — activity capture compounds switching cost every
+month, (b) making analysis *actionable* (leech trainer fed by confusion-pairs
+data nobody else has), and (c) answering our own users' requests fast (§2.1 —
+all three are covered by 2.26–2.28).
+
 Reference threads:
 - /reviews shutdown: https://community.wanikani.com/t/api-changes-get-all-reviews/61617
 - Wanilog: https://community.wanikani.com/t/wanilog-modern-wanikani-stats/74139
+- Wanilog vs wkstats comparison: https://wanilog.com/compare/wkstats
 - Heatmap: https://community.wanikani.com/t/userscript-wanikani-heatmap/34947
 - Item Inspector: https://community.wanikani.com/t/userscript-wanikani-item-inspector/44564
+- Self-Study Quiz: https://community.wanikani.com/t/userscript-self-study-quiz/13191
+
+### 2.1 User-request log (our community thread)
+
+Source: https://community.wanikani.com/t/i-built-a-wanikani-stats-tracker-with-some-features-i-thought-were-missing/72569
+
+| Request | Who / when | Status |
+|---|---|---|
+| Speedrun-aware projections: levels 1–2 and 43–60 are ~3d10h, others ~6d20h; project from *current* level, not uniform averages | NihongoDhruv, Dec 2025 | → 2.28 |
+| Related bug: speedrun pace computed slower than active pace | Shiveringomelet, Dec 2025 | → 2.28 |
+| Toggleable YYYY-MM-DD labels for exact level-up dates on the timeline | pabbles, Dec 2025 | → 2.28 |
+| JLPT readiness flexibility: real N-level coverage (not just Jōyō proxy), custom goal percentages, multiple measurement methods; cited wkstats' percentage coverage as the model | lizziemeaow, Mar 2026 | → 2.26 |
+| Broader community: custom item lists to quiz outside the review cycle (Apr 2025); review-availability notifications (recurring) | community-wide | → 2.25 pools / Tier 3 badge |
 
 ---
 
@@ -278,13 +307,35 @@ trustworthy.
 
 ## 7. Release roadmap
 
+Shipped:
+
+| Release | Theme | Contents |
+|---|---|---|
+| **2.21** ✅ | "Solid ground" | Offline & data durability (§6 work items): IDB migrations replace version-nuke, precache preserved, offline fallbacks, offline-aware sync UX. Closed #47: test harness + CI |
+| **2.22** ✅ | "The flight recorder" | Activity capture engine + SRS-distribution snapshots + streaks/records + history export-import |
+| **2.23** ✅ | "Show your work" | Activity heatmap page + share cards |
+| **2.24** ✅ | "Daily driver" | Level-up blockers on Dashboard + frequency coverage on Readiness |
+
+Planned (re-sequenced 2026-06-12 after competitive refresh):
+
 | Release | Theme | Contents | Rationale |
 |---|---|---|---|
-| **2.21** | "Solid ground" | Offline & data durability (§6 work items): IDB migrations replace version-nuke, precache preserved, user/resets offline fallbacks, summary fallback, offline-aware sync UX. **Closes #47**: test harness (runner + IDB fakes + CI step) ships here, migrations written test-first | Capture must not ship until the data layer stops eating itself; every later feature assumes durable local data and a working test setup |
-| **2.22** | "The flight recorder" | Activity capture engine + SRS-distribution snapshots + streaks/records display + history export-import | Irreplaceable data starts compounding the day it ships — everything visible can wait, capture cannot |
-| **2.23** | "Show your work" | Activity heatmap page + share cards | Visible payoff of captured data + first organic-growth feature; matches Wanilog's two flashiest capabilities in one release |
-| **2.24** | "Daily driver" | Level-up blockers on Dashboard + frequency coverage on Readiness | Shifts usage from "check weekly for stats" to "check daily to plan study" — that's what retention looks like |
-| 2.25 (tentative) | "Treatment, not just diagnosis" | Leech trainer (+ study materials sync) | Natural headline once the engagement loop is established |
+| **2.25** | "Treatment, not just diagnosis" | **Leech trainer**: flashcard quiz over leeches; **confusion-pair mode** (quiz visually-similar items against each other — unique to us); selectable item pools (leeches / recently failed / current level — answers the custom-lists community wish); audio from subject data; session results recorded locally. Study materials sync (§4.4) if it fits | Engagement loop; matches Wanilog's headline feature and beats it with confusion-pairs data |
+| **2.26** | "Real JLPT" | Direct **JLPT N5–N1 coverage** with drill-down, **custom goal %**, per-level coverage; keep Jōyō view alongside | Verbatim user request (§2.1) + the most-cited gap vs both Wanilog and wkstats; static data file + existing Readiness threshold UI |
+| **2.27** | "Can I read this?" | Paste-text readability analyzer: % readable at chosen SRS threshold, gap characters highlighted, each gap linked to its WaniKani item | High-delight, fully client-side, zero ongoing maintenance, very shareable. Deliberately *not* live NHK integration (Wanilog already walked theirs back) |
+| **2.28** | "Honest projections" | Speedrun-aware fast-level math (levels 1–2 / 43–60 at ~3d10h), median projection + confidence band, what-if pace slider, goal-date mode, exact level-up date labels on timeline; fixes the speedrun-pace bug | Clears the entire §2.1 projection backlog in one release; closes Wanilog's projection-math lead |
+| **2.29** | "Open door" | **Demo mode** (bundled sample dataset behind the setup page — explore without a token) + a wkstats comparison/SEO landing page | Acquisition: today every tokenless visitor bounces; Wanilog proved both plays work |
+
+Later bucket (sequenced behind the above): achievements (local-only, feeds
+share cards) · badge-only PWA notifications (§5.1) · heatmap per-day drill-down
+to item level (Kumirei parity — needs richer capture granularity; consider
+starting the richer capture earlier even if UI waits) · "WaniTrack Wrapped"
+Dec 2026 (§5.3) · manual known-kanji input · vocab/JLPT-vocab readiness (§5.4).
+
+Explicitly skipped: Japanese UI / palettes / cinematic replay (polish, not
+value), live NHK content (maintenance tail), offline reviews / write-API
+(different product category), public profiles / server-side anything (violates
+no-backend principle — our counter is the local moat + export).
 
 ---
 


### PR DESCRIPTION
## Summary
- Re-researched the competitive landscape (2026-06-12, at v2.24.0): rebuilt the §2 table — Wanilog has expanded substantially (calculator suite/SEO pages, demo mode, direct JLPT N-level coverage, confidence-interval projections, "Can I read this?") while still lacking any historical activity capture; wkstats continues to fade.
- Added §2.1 user-request log from the WaniTrack community thread, with each request mapped to a planned release.
- §7 roadmap: marked 2.21–2.24 shipped and re-sequenced the plan — 2.25 leech trainer (confusion-pair mode + selectable pools) → 2.26 Real JLPT → 2.27 "Can I read this?" → 2.28 Honest projections → 2.29 demo mode + wkstats comparison page — plus explicit later-bucket and skip list.
- Fixed two stale §1 lines (page count, test-suite status).

Doc-only change; no code.